### PR TITLE
Let-else reformatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "objdiff"
 version = "0.2.3"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.65"
 authors = ["Luke Street <luke@street.dev>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/encounter/objdiff"

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -211,25 +211,25 @@ fn address_eq(left: &ObjSymbol, right: &ObjSymbol) -> bool {
 }
 
 fn reloc_eq(left_reloc: Option<&ObjReloc>, right_reloc: Option<&ObjReloc>) -> bool {
-    if let (Some(left), Some(right)) = (left_reloc, right_reloc) {
-        if left.kind != right.kind {
-            return false;
+    let (Some(left), Some(right)) = (left_reloc, right_reloc) else {
+        return false;
+    };
+    if left.kind != right.kind {
+        return false;
+    }
+
+    let name_matches = left.target.name == right.target.name;
+    match (&left.target_section, &right.target_section) {
+        (Some(sl), Some(sr)) => {
+            // Match if section and name or address match
+            sl == sr && (name_matches || address_eq(&left.target, &right.target))
         }
-        let name_matches = left.target.name == right.target.name;
-        match (&left.target_section, &right.target_section) {
-            (Some(sl), Some(sr)) => {
-                // Match if section and name or address match
-                sl == sr && (name_matches || address_eq(&left.target, &right.target))
-            }
-            (Some(_), None) => false,
-            (None, Some(_)) => {
-                // Match if possibly stripped weak symbol
-                name_matches && right.target.flags.0.contains(ObjSymbolFlags::Weak)
-            }
-            (None, None) => name_matches,
+        (Some(_), None) => false,
+        (None, Some(_)) => {
+            // Match if possibly stripped weak symbol
+            name_matches && right.target.flags.0.contains(ObjSymbolFlags::Weak)
         }
-    } else {
-        false
+        (None, None) => name_matches,
     }
 }
 

--- a/src/views/data_diff.rs
+++ b/src/views/data_diff.rs
@@ -165,99 +165,91 @@ fn data_table_ui(
 
 pub fn data_diff_ui(ui: &mut egui::Ui, view_state: &mut ViewState) -> bool {
     let mut rebuild = false;
-    if let (Some(result), Some(selected_symbol)) = (&view_state.build, &view_state.selected_symbol)
-    {
-        StripBuilder::new(ui)
-            .size(Size::exact(20.0))
-            .size(Size::exact(40.0))
-            .size(Size::remainder())
-            .vertical(|mut strip| {
-                strip.strip(|builder| {
-                    builder.sizes(Size::remainder(), 2).horizontal(|mut strip| {
-                        strip.cell(|ui| {
-                            ui.horizontal(|ui| {
-                                if ui.button("Back").clicked() {
-                                    view_state.current_view = View::SymbolDiff;
-                                }
-                            });
-                        });
-                        strip.cell(|ui| {
-                            ui.horizontal(|ui| {
-                                if ui.button("Build").clicked() {
-                                    rebuild = true;
-                                }
-                                ui.scope(|ui| {
-                                    ui.style_mut().override_text_style =
-                                        Some(egui::TextStyle::Monospace);
-                                    ui.style_mut().wrap = Some(false);
-                                    if view_state
-                                        .jobs
-                                        .iter()
-                                        .any(|job| job.job_type == Job::ObjDiff)
-                                    {
-                                        ui.label("Building...");
-                                    } else {
-                                        ui.label("Last built:");
-                                        let format =
-                                            format_description::parse("[hour]:[minute]:[second]")
-                                                .unwrap();
-                                        ui.label(
-                                            result
-                                                .time
-                                                .to_offset(view_state.utc_offset)
-                                                .format(&format)
-                                                .unwrap(),
-                                        );
-                                    }
-                                });
-                            });
+    let (Some(result), Some(selected_symbol)) = (&view_state.build, &view_state.selected_symbol) else {
+        return rebuild;
+    };
+    StripBuilder::new(ui)
+        .size(Size::exact(20.0))
+        .size(Size::exact(40.0))
+        .size(Size::remainder())
+        .vertical(|mut strip| {
+            strip.strip(|builder| {
+                builder.sizes(Size::remainder(), 2).horizontal(|mut strip| {
+                    strip.cell(|ui| {
+                        ui.horizontal(|ui| {
+                            if ui.button("Back").clicked() {
+                                view_state.current_view = View::SymbolDiff;
+                            }
                         });
                     });
-                });
-                strip.strip(|builder| {
-                    builder.sizes(Size::remainder(), 2).horizontal(|mut strip| {
-                        strip.cell(|ui| {
+                    strip.cell(|ui| {
+                        ui.horizontal(|ui| {
+                            if ui.button("Build").clicked() {
+                                rebuild = true;
+                            }
                             ui.scope(|ui| {
                                 ui.style_mut().override_text_style =
                                     Some(egui::TextStyle::Monospace);
                                 ui.style_mut().wrap = Some(false);
-                                ui.colored_label(Color32::WHITE, &selected_symbol.symbol_name);
-                                ui.label("Diff target:");
-                                ui.separator();
-                            });
-                        });
-                        strip.cell(|ui| {
-                            ui.scope(|ui| {
-                                ui.style_mut().override_text_style =
-                                    Some(egui::TextStyle::Monospace);
-                                ui.style_mut().wrap = Some(false);
-                                ui.label("");
-                                ui.label("Diff base:");
-                                ui.separator();
+                                if view_state.jobs.iter().any(|job| job.job_type == Job::ObjDiff) {
+                                    ui.label("Building...");
+                                } else {
+                                    ui.label("Last built:");
+                                    let format =
+                                        format_description::parse("[hour]:[minute]:[second]")
+                                            .unwrap();
+                                    ui.label(
+                                        result
+                                            .time
+                                            .to_offset(view_state.utc_offset)
+                                            .format(&format)
+                                            .unwrap(),
+                                    );
+                                }
                             });
                         });
                     });
-                });
-                strip.cell(|ui| {
-                    if let (Some(left_obj), Some(right_obj)) =
-                        (&result.first_obj, &result.second_obj)
-                    {
-                        let table = TableBuilder::new(ui)
-                            .striped(false)
-                            .cell_layout(egui::Layout::left_to_right(egui::Align::Min))
-                            .column(Size::relative(0.5))
-                            .column(Size::relative(0.5))
-                            .resizable(false);
-                        data_table_ui(
-                            table,
-                            left_obj,
-                            right_obj,
-                            selected_symbol,
-                            &view_state.view_config,
-                        );
-                    }
                 });
             });
-    }
+            strip.strip(|builder| {
+                builder.sizes(Size::remainder(), 2).horizontal(|mut strip| {
+                    strip.cell(|ui| {
+                        ui.scope(|ui| {
+                            ui.style_mut().override_text_style = Some(egui::TextStyle::Monospace);
+                            ui.style_mut().wrap = Some(false);
+                            ui.colored_label(Color32::WHITE, &selected_symbol.symbol_name);
+                            ui.label("Diff target:");
+                            ui.separator();
+                        });
+                    });
+                    strip.cell(|ui| {
+                        ui.scope(|ui| {
+                            ui.style_mut().override_text_style = Some(egui::TextStyle::Monospace);
+                            ui.style_mut().wrap = Some(false);
+                            ui.label("");
+                            ui.label("Diff base:");
+                            ui.separator();
+                        });
+                    });
+                });
+            });
+            strip.cell(|ui| {
+                if let (Some(left_obj), Some(right_obj)) = (&result.first_obj, &result.second_obj) {
+                    let table = TableBuilder::new(ui)
+                        .striped(false)
+                        .cell_layout(egui::Layout::left_to_right(egui::Align::Min))
+                        .column(Size::relative(0.5))
+                        .column(Size::relative(0.5))
+                        .resizable(false);
+                    data_table_ui(
+                        table,
+                        left_obj,
+                        right_obj,
+                        selected_symbol,
+                        &view_state.view_config,
+                    );
+                }
+            });
+        });
     rebuild
 }

--- a/src/views/jobs.rs
+++ b/src/views/jobs.rs
@@ -7,46 +7,47 @@ pub fn jobs_ui(ui: &mut egui::Ui, view_state: &mut ViewState) {
 
     let mut remove_job: Option<usize> = None;
     for (idx, job) in view_state.jobs.iter_mut().enumerate() {
-        if let Ok(status) = job.status.read() {
-            ui.group(|ui| {
-                ui.horizontal(|ui| {
-                    ui.label(&status.title);
-                    if ui.small_button("✖").clicked() {
-                        if job.handle.is_some() {
-                            job.should_remove = true;
-                            if let Err(e) = job.cancel.send(()) {
-                                eprintln!("Failed to cancel job: {e:?}");
-                            }
-                        } else {
-                            remove_job = Some(idx);
+        let Ok(status) = job.status.read() else {
+            continue;
+        };
+        ui.group(|ui| {
+            ui.horizontal(|ui| {
+                ui.label(&status.title);
+                if ui.small_button("✖").clicked() {
+                    if job.handle.is_some() {
+                        job.should_remove = true;
+                        if let Err(e) = job.cancel.send(()) {
+                            eprintln!("Failed to cancel job: {e:?}");
                         }
-                    }
-                });
-                let mut bar = ProgressBar::new(status.progress_percent);
-                if let Some(items) = &status.progress_items {
-                    bar = bar.text(format!("{} / {}", items[0], items[1]));
-                }
-                bar.ui(ui);
-                const STATUS_LENGTH: usize = 80;
-                if let Some(err) = &status.error {
-                    let err_string = err.to_string();
-                    ui.colored_label(
-                        Color32::from_rgb(255, 0, 0),
-                        if err_string.len() > STATUS_LENGTH - 10 {
-                            format!("Error: {}...", &err_string[0..STATUS_LENGTH - 10])
-                        } else {
-                            format!("Error: {:width$}", err_string, width = STATUS_LENGTH - 7)
-                        },
-                    );
-                } else {
-                    ui.label(if status.status.len() > STATUS_LENGTH - 3 {
-                        format!("{}...", &status.status[0..STATUS_LENGTH - 3])
                     } else {
-                        format!("{:width$}", &status.status, width = STATUS_LENGTH)
-                    });
+                        remove_job = Some(idx);
+                    }
                 }
             });
-        }
+            let mut bar = ProgressBar::new(status.progress_percent);
+            if let Some(items) = &status.progress_items {
+                bar = bar.text(format!("{} / {}", items[0], items[1]));
+            }
+            bar.ui(ui);
+            const STATUS_LENGTH: usize = 80;
+            if let Some(err) = &status.error {
+                let err_string = err.to_string();
+                ui.colored_label(
+                    Color32::from_rgb(255, 0, 0),
+                    if err_string.len() > STATUS_LENGTH - 10 {
+                        format!("Error: {}...", &err_string[0..STATUS_LENGTH - 10])
+                    } else {
+                        format!("Error: {:width$}", err_string, width = STATUS_LENGTH - 7)
+                    },
+                );
+            } else {
+                ui.label(if status.status.len() > STATUS_LENGTH - 3 {
+                    format!("{}...", &status.status[0..STATUS_LENGTH - 3])
+                } else {
+                    format!("{:width$}", &status.status, width = STATUS_LENGTH)
+                });
+            }
+        });
     }
 
     if let Some(idx) = remove_job {


### PR DESCRIPTION
Changes made to use the [let-else](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#let-else-statements) construct where it improves readability. I targeted the code sections that benefited the most. It is somewhat a stylistic/subjective decision in different cases, so I made each change a separate commit in case you want to drop one or more of them.