### PR TITLE
Add `#[serde(default)]` to `ReportFunction::address`

### DIFF
--- a/objdiff-cli/src/cmd/report.rs
+++ b/objdiff-cli/src/cmd/report.rs
@@ -95,6 +95,7 @@ struct ReportFunction {
     #[serde(skip_serializing_if = "Option::is_none")]
     demangled_name: Option<String>,
     #[serde(
+        default,
         skip_serializing_if = "Option::is_none",
         serialize_with = "serialize_hex",
         deserialize_with = "deserialize_hex"


### PR DESCRIPTION
When running `objdiff report changes` on a report generated by `objdiff report generate`, if any function is missing an address, deserialization will fail. This is because the default `Option` deserialization behavior is [overwritten by the other processors](https://stackoverflow.com/a/44303505). This change fixes that.