### PR TITLE
objdiff-cli diff: Accept any kind of unit path

### DIFF
--- a/objdiff-cli/src/cmd/diff.rs
+++ b/objdiff-cli/src/cmd/diff.rs
@@ -96,7 +96,7 @@ pub fn run(args: Args) -> Result<()> {
                                 return Some(obj);
                             }
 
-                            return None;
+                            None
                         }) else {
                             bail!("Unit not found: {}", u)
                         };

--- a/objdiff-cli/src/cmd/diff.rs
+++ b/objdiff-cli/src/cmd/diff.rs
@@ -78,15 +78,16 @@ pub fn run(args: Args) -> Result<()> {
                             PathBuf::from_str(u).ok().and_then(|p| fs::canonicalize(p).ok());
 
                         let Some(object) = project_config.objects.iter_mut().find_map(|obj| {
-                            resolve_paths(obj);
-
                             if obj.name.as_deref() == Some(u) {
+                                resolve_paths(obj);
                                 return Some(obj);
                             }
 
                             let Some(up) = unit_path.as_deref() else {
                                 return None;
                             };
+
+                            resolve_paths(obj);
 
                             if [&obj.base_path, &obj.target_path]
                                 .into_iter()


### PR DESCRIPTION
All of these are now valid:
```
objdiff-cli diff -u main/melee/ft/chara/ftCommon/ftCo_AttackDash doEnter
objdiff-cli diff -u build/GALE01/src/melee/ft/chara/ftCommon/ftCo_AttackDash.o doEnter
objdiff-cli diff -u build/GALE01/obj/melee/ft/chara/ftCommon/ftCo_AttackDash.o doEnter
```

Makes scripting less painful, and shells offer completion for filesystem paths but not for objdiff unit paths.