### PR TITLE
Fix release CI (and add `sccache`)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -131,7 +131,7 @@ jobs:
           RUSTC_WRAPPER: "sccache"
         run: >
           cargo build --profile ${{ env.BUILD_PROFILE }} --target ${{ matrix.target }} 
-          --bin objdiff-cli --bin objdiff-gui --features ${{ matrix.features }}
+          --bin objdiff-cli --bin objdiff --features ${{ matrix.features }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -139,8 +139,8 @@ jobs:
           path: |
             ${{ env.CARGO_TARGET_DIR }}/${{ matrix.target }}/${{ env.BUILD_PROFILE }}/objdiff-cli
             ${{ env.CARGO_TARGET_DIR }}/${{ matrix.target }}/${{ env.BUILD_PROFILE }}/objdiff-cli.exe
-            ${{ env.CARGO_TARGET_DIR }}/${{ matrix.target }}/${{ env.BUILD_PROFILE }}/objdiff-gui
-            ${{ env.CARGO_TARGET_DIR }}/${{ matrix.target }}/${{ env.BUILD_PROFILE }}/objdiff-gui.exe
+            ${{ env.CARGO_TARGET_DIR }}/${{ matrix.target }}/${{ env.BUILD_PROFILE }}/objdiff
+            ${{ env.CARGO_TARGET_DIR }}/${{ matrix.target }}/${{ env.BUILD_PROFILE }}/objdiff.exe
           if-no-files-found: error
 
   release:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -117,6 +117,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install ${{ matrix.packages }}
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.3
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Rust toolchain
@@ -124,6 +126,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - name: Cargo build
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
         run: >
           cargo build --profile ${{ env.BUILD_PROFILE }} --target ${{ matrix.target }} 
           --bin objdiff-cli --bin objdiff-gui --features ${{ matrix.features }}
@@ -143,6 +148,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: [ build ]
+    permissions:
+      contents: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -151,12 +158,21 @@ jobs:
       - name: Rename artifacts
         working-directory: artifacts
         run: |
+          set -euo pipefail
           mkdir ../out
-          for i in */*/$BUILD_PROFILE/objdiff-cli*; do
-            mv "$i" "../out/$(sed -E "s/([^/]+)\/[^/]+\/$BUILD_PROFILE\/objdiff-cli/objdiff-cli-\1/" <<< "$i")"
-          done
-          for i in */*/$BUILD_PROFILE/objdiff-gui*; do
-            mv "$i" "../out/$(sed -E "s/([^/]+)\/[^/]+\/$BUILD_PROFILE\/objdiff-gui/objdiff-\1/" <<< "$i")"
+          for dir in */; do
+            for file in "$dir"*; do
+              base=$(basename "$file")
+              name="${base%.*}"
+              ext="${base##*.}"
+              if [ "$ext" = "$base" ]; then
+                  ext=""
+              else
+                  ext=".$ext"
+              fi
+              dst="../out/${name}-${dir%/}${ext}"
+              mv "$file" "$dst"
+            done
           done
           ls -R ../out
       - name: Release

--- a/objdiff-gui/Cargo.toml
+++ b/objdiff-gui/Cargo.toml
@@ -13,6 +13,10 @@ A local diffing tool for decompilation projects.
 publish = false
 build = "build.rs"
 
+[[bin]]
+name = "objdiff"
+path = "src/main.rs"
+
 [features]
 default = ["wgpu", "wsl"]
 wgpu = ["eframe/wgpu"]


### PR DESCRIPTION
* [Before](https://github.com/ribbanya/objdiff/actions/runs/8125861243/job/22208993779#step:3:15)
* [After](https://github.com/ribbanya/objdiff/actions/runs/8126527427/job/22210495357#step:3:24)

`sccache` saves a little bit of time, it's hard to say how much. On `ubuntu-latest` it's like 3 minutes saved, but on Windows it's more marginal. :shrug:

`contents: write` was necessary to avoid 403 errors on my fork.