### PR TITLE
Add custom make args

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ file as well. You can then add `objdiff.json` to your `.gitignore` to prevent it
 // objdiff.json
 {
   "custom_make": "ninja",
+  "custom_args": [
+    "-C",
+    "build"
+  ],
 
   // Only required if objects use "path" instead of "target_path" and "base_path".
   "target_dir": "build/asm",

--- a/objdiff-core/src/config/mod.rs
+++ b/objdiff-core/src/config/mod.rs
@@ -18,6 +18,8 @@ pub struct ProjectConfig {
     #[serde(default)]
     pub custom_make: Option<String>,
     #[serde(default)]
+    pub custom_args: Option<Vec<String>>,
+    #[serde(default)]
     pub target_dir: Option<PathBuf>,
     #[serde(default)]
     pub base_dir: Option<PathBuf>,

--- a/objdiff-gui/src/app.rs
+++ b/objdiff-gui/src/app.rs
@@ -84,6 +84,8 @@ pub struct AppConfig {
     #[serde(default)]
     pub custom_make: Option<String>,
     #[serde(default)]
+    pub custom_args: Option<Vec<String>>,
+    #[serde(default)]
     pub selected_wsl_distro: Option<String>,
     #[serde(default)]
     pub project_dir: Option<PathBuf>,
@@ -131,6 +133,7 @@ impl Default for AppConfig {
         Self {
             version: AppConfigVersion::default().version,
             custom_make: None,
+            custom_args: None,
             selected_wsl_distro: None,
             project_dir: None,
             target_obj_dir: None,

--- a/objdiff-gui/src/config.rs
+++ b/objdiff-gui/src/config.rs
@@ -71,6 +71,7 @@ pub fn load_project_config(config: &mut AppConfig) -> Result<()> {
     if let Some((result, info)) = try_project_config(project_dir) {
         let project_config = result?;
         config.custom_make = project_config.custom_make;
+        config.custom_args = project_config.custom_args;
         config.target_obj_dir = project_config.target_dir.map(|p| project_dir.join(p));
         config.base_obj_dir = project_config.base_dir.map(|p| project_dir.join(p));
         config.build_base = project_config.build_base;


### PR DESCRIPTION
A `custom_make` option such as `make MY_VALUE=1` is interpreted as an entire command with no arguments. So, to allow for custom arguments, I've added a `custom_args` option.

I hope the README example makes sense, I haven't used Ninja before 🙃