### PR TITLE
Fix size of .note.split section

### DIFF
--- a/objdiff-core/src/obj/split_meta.rs
+++ b/objdiff-core/src/obj/split_meta.rs
@@ -190,7 +190,7 @@ where E: Endian
     }
 }
 
-fn align_size_to_4(size: usize) -> usize { return (size + 3) & !3; }
+fn align_size_to_4(size: usize) -> usize { (size + 3) & !3 }
 
 fn align_data_to_4<W: Write + ?Sized>(writer: &mut W, len: usize) -> io::Result<()> {
     const ALIGN_BYTES: &[u8] = &[0; 4];


### PR DESCRIPTION
The latest dtk release creates a `.note.split` section with a size too small because it does not take note alignment into account, causing objdiff to fail when trying to read the object file