### PR TITLE
Use base arch when processing base code

### DIFF
--- a/objdiff-core/src/diff/code.rs
+++ b/objdiff-core/src/diff/code.rs
@@ -39,7 +39,7 @@ pub fn diff_code(
     config: &DiffObjConfig,
 ) -> Result<(ObjSymbolDiff, ObjSymbolDiff)> {
     let left_out = left_obj.arch.process_code(left_obj, left_symbol_ref, config)?;
-    let right_out = left_obj.arch.process_code(right_obj, right_symbol_ref, config)?;
+    let right_out = right_obj.arch.process_code(right_obj, right_symbol_ref, config)?;
 
     let mut left_diff = Vec::<ObjInsDiff>::new();
     let mut right_diff = Vec::<ObjInsDiff>::new();


### PR DESCRIPTION
When diffing target against base, the `diff_code` function uses the target arch object to process code for *both* target and base, and the base arch object goes unused.

From what I can tell, all currently supported architectures have the same parameters in the two arch objects, so it doesn't matter which one gets used to process code. However, I'm working on supporting ARMv5TE, and my arch objects [can have different parameters](https://github.com/AetiasHax/objdiff/blob/2d06abec1954933c7e4b5ea9b075affde165fbc1/objdiff-core/src/arch/arm.rs#L25).