### PR TITLE
Display correct line numbers for multiple .text sections

### DIFF
--- a/objdiff-core/src/arch/mips.rs
+++ b/objdiff-core/src/arch/mips.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use anyhow::{bail, Result};
-use object::{elf, Endian, Endianness, File, Object, Relocation, RelocationFlags, SectionIndex};
+use object::{elf, Endian, Endianness, File, Object, Relocation, RelocationFlags};
 use rabbitizer::{config, Abi, InstrCategory, Instruction, OperandType};
 
 use crate::{
@@ -37,9 +37,6 @@ impl ObjArch for ObjArchMips {
         let (section, symbol) = obj.section_symbol(symbol_ref);
         let code = &section.data
             [symbol.section_address as usize..(symbol.section_address + symbol.size) as usize];
-
-        let line_info =
-            obj.line_info.as_ref().and_then(|map| map.get(&SectionIndex(section.orig_index)));
 
         let start_address = symbol.address;
         let end_address = symbol.address + symbol.size;
@@ -114,8 +111,10 @@ impl ObjArch for ObjArchMips {
                     }
                 }
             }
-            let line =
-                line_info.and_then(|map| map.range(..=cur_addr as u64).last().map(|(_, &b)| b));
+            let line = section
+                .line_info
+                .as_ref()
+                .and_then(|map| map.range(..=cur_addr as u64).last().map(|(_, &b)| b));
             insts.push(ObjIns {
                 address: cur_addr as u64,
                 size: 4,

--- a/objdiff-core/src/arch/mips.rs
+++ b/objdiff-core/src/arch/mips.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use anyhow::{bail, Result};
-use object::{elf, Endian, Endianness, File, Object, Relocation, RelocationFlags};
+use object::{elf, Endian, Endianness, File, Object, Relocation, RelocationFlags, SectionIndex};
 use rabbitizer::{config, Abi, InstrCategory, Instruction, OperandType};
 
 use crate::{
@@ -37,6 +37,9 @@ impl ObjArch for ObjArchMips {
         let (section, symbol) = obj.section_symbol(symbol_ref);
         let code = &section.data
             [symbol.section_address as usize..(symbol.section_address + symbol.size) as usize];
+
+        let line_info =
+            obj.line_info.as_ref().and_then(|map| map.get(&SectionIndex(section.orig_index)));
 
         let start_address = symbol.address;
         let end_address = symbol.address + symbol.size;
@@ -110,10 +113,8 @@ impl ObjArch for ObjArchMips {
                     }
                 }
             }
-            let line = obj
-                .line_info
-                .as_ref()
-                .and_then(|map| map.range(..=cur_addr as u64).last().map(|(_, &b)| b));
+            let line =
+                line_info.and_then(|map| map.range(..=cur_addr as u64).last().map(|(_, &b)| b));
             insts.push(ObjIns {
                 address: cur_addr as u64,
                 size: 4,

--- a/objdiff-core/src/arch/mips.rs
+++ b/objdiff-core/src/arch/mips.rs
@@ -111,10 +111,7 @@ impl ObjArch for ObjArchMips {
                     }
                 }
             }
-            let line = section
-                .line_info
-                .as_ref()
-                .and_then(|map| map.range(..=cur_addr as u64).last().map(|(_, &b)| b));
+            let line = section.line_info.range(..=cur_addr as u64).last().map(|(_, &b)| b);
             insts.push(ObjIns {
                 address: cur_addr as u64,
                 size: 4,

--- a/objdiff-core/src/arch/ppc.rs
+++ b/objdiff-core/src/arch/ppc.rs
@@ -132,10 +132,7 @@ impl ObjArch for ObjArchPpc {
             }
 
             ops.push(ins.op as u16);
-            let line = section
-                .line_info
-                .as_ref()
-                .and_then(|map| map.range(..=cur_addr as u64).last().map(|(_, &b)| b));
+            let line = section.line_info.range(..=cur_addr as u64).last().map(|(_, &b)| b);
             insts.push(ObjIns {
                 address: cur_addr as u64,
                 size: 4,

--- a/objdiff-core/src/arch/ppc.rs
+++ b/objdiff-core/src/arch/ppc.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use anyhow::{bail, Result};
-use object::{elf, File, Relocation, RelocationFlags, SectionIndex};
+use object::{elf, File, Relocation, RelocationFlags};
 use ppc750cl::{Argument, InsIter, GPR};
 
 use crate::{
@@ -38,9 +38,6 @@ impl ObjArch for ObjArchPpc {
         let (section, symbol) = obj.section_symbol(symbol_ref);
         let code = &section.data
             [symbol.section_address as usize..(symbol.section_address + symbol.size) as usize];
-
-        let line_info =
-            obj.line_info.as_ref().and_then(|map| map.get(&SectionIndex(section.orig_index)));
 
         let ins_count = code.len() / 4;
         let mut ops = Vec::<u16>::with_capacity(ins_count);
@@ -135,8 +132,10 @@ impl ObjArch for ObjArchPpc {
             }
 
             ops.push(ins.op as u16);
-            let line =
-                line_info.and_then(|map| map.range(..=cur_addr as u64).last().map(|(_, &b)| b));
+            let line = section
+                .line_info
+                .as_ref()
+                .and_then(|map| map.range(..=cur_addr as u64).last().map(|(_, &b)| b));
             insts.push(ObjIns {
                 address: cur_addr as u64,
                 size: 4,

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -73,7 +73,7 @@ impl ObjArch for ObjArchX86 {
                 .relocations
                 .iter()
                 .find(|r| r.address >= address && r.address < address + instruction.len() as u64);
-            let line = section.line_info.as_ref().and_then(|m| m.get(&address).cloned());
+            let line = section.line_info.range(..=address).last().map(|(_, &b)| b);
             output.ins = ObjIns {
                 address,
                 size: instruction.len() as u8,

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -6,7 +6,7 @@ use iced_x86::{
     GasFormatter, Instruction, IntelFormatter, MasmFormatter, NasmFormatter, NumberKind, OpKind,
     PrefixKind, Register,
 };
-use object::{pe, Endian, Endianness, File, Object, Relocation, RelocationFlags, SectionIndex};
+use object::{pe, Endian, Endianness, File, Object, Relocation, RelocationFlags};
 
 use crate::{
     arch::{ObjArch, ProcessCodeResult},
@@ -35,9 +35,6 @@ impl ObjArch for ObjArchX86 {
         let (section, symbol) = obj.section_symbol(symbol_ref);
         let code = &section.data
             [symbol.section_address as usize..(symbol.section_address + symbol.size) as usize];
-
-        let line_info =
-            obj.line_info.as_ref().and_then(|map| map.get(&SectionIndex(section.orig_index)));
 
         let mut result = ProcessCodeResult { ops: Vec::new(), insts: Vec::new() };
         let mut decoder = Decoder::with_ip(self.bits, code, symbol.address, DecoderOptions::NONE);
@@ -76,6 +73,7 @@ impl ObjArch for ObjArchX86 {
                 .relocations
                 .iter()
                 .find(|r| r.address >= address && r.address < address + instruction.len() as u64);
+            let line = section.line_info.as_ref().and_then(|m| m.get(&address).cloned());
             output.ins = ObjIns {
                 address,
                 size: instruction.len() as u8,
@@ -84,7 +82,7 @@ impl ObjArch for ObjArchX86 {
                 args: vec![],
                 reloc: reloc.cloned(),
                 branch_dest: None,
-                line: line_info.and_then(|m| m.get(&address).cloned()),
+                line,
                 formatted: String::new(),
                 orig: None,
             };

--- a/objdiff-core/src/obj/mod.rs
+++ b/objdiff-core/src/obj/mod.rs
@@ -40,7 +40,7 @@ pub struct ObjSection {
     pub relocations: Vec<ObjReloc>,
     pub virtual_address: Option<u64>,
     /// Line number info (.line or .debug_line section)
-    pub line_info: Option<BTreeMap<u64, u64>>,
+    pub line_info: BTreeMap<u64, u64>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/objdiff-core/src/obj/mod.rs
+++ b/objdiff-core/src/obj/mod.rs
@@ -1,11 +1,16 @@
 pub mod read;
 pub mod split_meta;
 
-use std::{borrow::Cow, collections::BTreeMap, fmt, path::PathBuf};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashMap},
+    fmt,
+    path::PathBuf,
+};
 
 use filetime::FileTime;
 use flagset::{flags, FlagSet};
-use object::RelocationFlags;
+use object::{RelocationFlags, SectionIndex};
 use split_meta::SplitMeta;
 
 use crate::{arch::ObjArch, util::ReallySigned};
@@ -127,7 +132,7 @@ pub struct ObjInfo {
     /// Common BSS symbols
     pub common: Vec<ObjSymbol>,
     /// Line number info (.line or .debug_line section)
-    pub line_info: Option<BTreeMap<u64, u64>>,
+    pub line_info: Option<HashMap<SectionIndex, BTreeMap<u64, u64>>>,
     /// Split object metadata (.note.split section)
     pub split_meta: Option<SplitMeta>,
 }

--- a/objdiff-core/src/obj/mod.rs
+++ b/objdiff-core/src/obj/mod.rs
@@ -1,16 +1,11 @@
 pub mod read;
 pub mod split_meta;
 
-use std::{
-    borrow::Cow,
-    collections::{BTreeMap, HashMap},
-    fmt,
-    path::PathBuf,
-};
+use std::{borrow::Cow, collections::BTreeMap, fmt, path::PathBuf};
 
 use filetime::FileTime;
 use flagset::{flags, FlagSet};
-use object::{RelocationFlags, SectionIndex};
+use object::RelocationFlags;
 use split_meta::SplitMeta;
 
 use crate::{arch::ObjArch, util::ReallySigned};
@@ -44,6 +39,8 @@ pub struct ObjSection {
     pub symbols: Vec<ObjSymbol>,
     pub relocations: Vec<ObjReloc>,
     pub virtual_address: Option<u64>,
+    /// Line number info (.line or .debug_line section)
+    pub line_info: Option<BTreeMap<u64, u64>>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -133,8 +130,6 @@ pub struct ObjInfo {
     pub sections: Vec<ObjSection>,
     /// Common BSS symbols
     pub common: Vec<ObjSymbol>,
-    /// Line number info (.line or .debug_line section)
-    pub line_info: Option<HashMap<SectionIndex, BTreeMap<u64, u64>>>,
     /// Split object metadata (.note.split section)
     pub split_meta: Option<SplitMeta>,
 }


### PR DESCRIPTION
Object files with multiple .text sections currently display incorrect line numbers. This is because we are storing line info by mapping an address to a line number, not taking section index into consideration.

DWARF 2.0+ supports multiple .text sections by defining multiple "sequences", where each sequence starts from address 0 and correlates to one `.text` section. I've implemented support for this, by iterating to the next code section whenever a sequence ends. This means the line info is now mapping section index, to address, to line number.

From what I've read, DWARF does not define *how* it correlates a sequence to a section. I've made an assumption and believe that the first sequence should correlate to the first code section, and so on.

I haven't tested this on all the architectures that objdiff supports, but I'd be happy to do so if anyone can provide some object files.