### PR TITLE
Fix read error on objects with no .text section

### DIFF
--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -328,15 +328,10 @@ fn line_info(obj_file: &File<'_>, sections: &mut [ObjSection]) -> Result<()> {
             if let Some(program) = unit.line_program.clone() {
                 let mut text_sections =
                     obj_file.sections().filter(|s| s.kind() == SectionKind::Text);
-                let section_index = text_sections
-                    .next()
-                    .ok_or_else(|| anyhow!("Next text section not found for line info"))?
-                    .index()
-                    .0;
-                let mut lines = sections
-                    .iter_mut()
-                    .find(|s| s.orig_index == section_index)
-                    .map(|s| &mut s.line_info);
+                let section_index = text_sections.next().map(|s| s.index().0);
+                let mut lines = section_index.map(|index| {
+                    &mut sections.iter_mut().find(|s| s.orig_index == index).unwrap().line_info
+                });
 
                 let mut rows = program.rows();
                 while let Some((_header, row)) = rows.next_row()? {

--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -277,11 +277,13 @@ fn line_info(obj_file: &File<'_>, sections: &mut [ObjSection]) -> Result<()> {
 
         let mut text_sections = obj_file.sections().filter(|s| s.kind() == SectionKind::Text);
         while reader.position() < data.len() as u64 {
-            let text_section_index = text_sections
-                .next()
-                .ok_or_else(|| anyhow!("Next text section not found for line info"))?
-                .index()
-                .0;
+            let text_section_index = if let Some(index) = text_sections.next().map(|s| s.index().0)
+            {
+                index
+            } else {
+                // No more text sections to generate line info for
+                break;
+            };
             let start = reader.position();
             let size = reader.read_u32::<BigEndian>()?;
             let base_address = reader.read_u32::<BigEndian>()? as u64;

--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -277,13 +277,11 @@ fn line_info(obj_file: &File<'_>, sections: &mut [ObjSection]) -> Result<()> {
 
         let mut text_sections = obj_file.sections().filter(|s| s.kind() == SectionKind::Text);
         while reader.position() < data.len() as u64 {
-            let text_section_index = if let Some(index) = text_sections.next().map(|s| s.index().0)
-            {
-                index
-            } else {
-                // No more text sections to generate line info for
-                break;
-            };
+            let text_section_index = text_sections
+                .next()
+                .ok_or_else(|| anyhow!("Next text section not found for line info"))?
+                .index()
+                .0;
             let start = reader.position();
             let size = reader.read_u32::<BigEndian>()?;
             let base_address = reader.read_u32::<BigEndian>()? as u64;


### PR DESCRIPTION
The DWARF parser errors on object files with no .text sections, which makes it impossible to open objects where the target doesn't contain code yet.

I fixed this for both DWARF 1.1 and 2+, but I don't have a DWARF 1.1 object to test with so I suggest doing so before merging.