### PR TITLE
Combine data sections with equal names

### DIFF
--- a/objdiff-cli/src/cmd/report.rs
+++ b/objdiff-cli/src/cmd/report.rs
@@ -230,17 +230,21 @@ fn report_object(
         }
         _ => {}
     }
+    let config = diff::DiffObjConfig { relax_reloc_diffs: true, ..Default::default() };
     let target = object
         .target_path
         .as_ref()
-        .map(|p| obj::read::read(p).with_context(|| format!("Failed to open {}", p.display())))
+        .map(|p| {
+            obj::read::read(p, &config).with_context(|| format!("Failed to open {}", p.display()))
+        })
         .transpose()?;
     let base = object
         .base_path
         .as_ref()
-        .map(|p| obj::read::read(p).with_context(|| format!("Failed to open {}", p.display())))
+        .map(|p| {
+            obj::read::read(p, &config).with_context(|| format!("Failed to open {}", p.display()))
+        })
         .transpose()?;
-    let config = diff::DiffObjConfig { relax_reloc_diffs: true, ..Default::default() };
     let result = diff::diff_objs(&config, target.as_ref(), base.as_ref(), None)?;
     let mut unit = ReportUnit {
         name: object.name().to_string(),

--- a/objdiff-core/src/diff/mod.rs
+++ b/objdiff-core/src/diff/mod.rs
@@ -102,6 +102,7 @@ pub struct DiffObjConfig {
     pub relax_reloc_diffs: bool,
     #[serde(default = "default_true")]
     pub space_between_args: bool,
+    pub combine_data_sections: bool,
     // x86
     pub x86_formatter: X86Formatter,
     // MIPS
@@ -114,6 +115,7 @@ impl Default for DiffObjConfig {
         Self {
             relax_reloc_diffs: false,
             space_between_args: true,
+            combine_data_sections: false,
             x86_formatter: Default::default(),
             mips_abi: Default::default(),
             mips_instr_category: Default::default(),

--- a/objdiff-gui/src/app.rs
+++ b/objdiff-gui/src/app.rs
@@ -559,6 +559,16 @@ impl eframe::App for App {
                     {
                         config.queue_reload = true;
                     }
+                    if ui
+                        .checkbox(
+                            &mut config.diff_obj_config.combine_data_sections,
+                            "Combine data sections",
+                        )
+                        .on_hover_text("Combines data sections with equal names.")
+                        .changed()
+                    {
+                        config.queue_reload = true;
+                    }
                 });
             });
         });

--- a/objdiff-gui/src/jobs/objdiff.rs
+++ b/objdiff-gui/src/jobs/objdiff.rs
@@ -235,7 +235,7 @@ fn run_build(
                     total,
                     &cancel,
                 )?;
-                Some(read::read(target_path).with_context(|| {
+                Some(read::read(target_path, &config.diff_obj_config).with_context(|| {
                     format!("Failed to read object '{}'", target_path.display())
                 })?)
             }
@@ -252,7 +252,7 @@ fn run_build(
                 &cancel,
             )?;
             Some(
-                read::read(base_path)
+                read::read(base_path, &config.diff_obj_config)
                     .with_context(|| format!("Failed to read object '{}'", base_path.display()))?,
             )
         }


### PR DESCRIPTION
Some compilers such as `mwccarm` can generate multiple `.data` sections in the same object file, but clicking a data symbol in objdiff shows a hex view for only the first `.data` section. Meanwhile, the target object has only one `.data` section, so the hex view is diffing all of the target data with only a single chunk of base object data.

My proposed solution is to "combine" sections with equal names, ordered from lowest to highest section index. There's a checkbox under "Diff Options" to enable this when needed.