### PR TITLE
Support R_MIPS_GPREL16 relocations correctly

### DIFF
--- a/objdiff-core/src/arch/arm.rs
+++ b/objdiff-core/src/arch/arm.rs
@@ -48,10 +48,13 @@ impl ObjArchArm {
             s.kind() == SectionKind::Elf(SHT_ARM_ATTRIBUTES) && s.name() == Ok(".ARM.attributes")
         }) {
             let attr_data = arm_attrs.uncompressed_data()?;
-            let build_attrs = BuildAttrs::new(&attr_data, match file.endianness() {
-                object::Endianness::Little => arm_attr::Endian::Little,
-                object::Endianness::Big => arm_attr::Endian::Big,
-            })?;
+            let build_attrs = BuildAttrs::new(
+                &attr_data,
+                match file.endianness() {
+                    object::Endianness::Little => arm_attr::Endian::Little,
+                    object::Endianness::Big => arm_attr::Endian::Big,
+                },
+            )?;
             for subsection in build_attrs.subsections() {
                 let subsection = subsection?;
                 if !subsection.is_aeabi() {
@@ -227,6 +230,7 @@ impl ObjArch for ObjArchArm {
 
     fn implcit_addend(
         &self,
+        _file: &File<'_>,
         section: &ObjSection,
         address: u64,
         reloc: &Relocation,

--- a/objdiff-core/src/arch/arm.rs
+++ b/objdiff-core/src/arch/arm.rs
@@ -48,13 +48,10 @@ impl ObjArchArm {
             s.kind() == SectionKind::Elf(SHT_ARM_ATTRIBUTES) && s.name() == Ok(".ARM.attributes")
         }) {
             let attr_data = arm_attrs.uncompressed_data()?;
-            let build_attrs = BuildAttrs::new(
-                &attr_data,
-                match file.endianness() {
-                    object::Endianness::Little => arm_attr::Endian::Little,
-                    object::Endianness::Big => arm_attr::Endian::Big,
-                },
-            )?;
+            let build_attrs = BuildAttrs::new(&attr_data, match file.endianness() {
+                object::Endianness::Little => arm_attr::Endian::Little,
+                object::Endianness::Big => arm_attr::Endian::Big,
+            })?;
             for subsection in build_attrs.subsections() {
                 let subsection = subsection?;
                 if !subsection.is_aeabi() {

--- a/objdiff-core/src/arch/mips.rs
+++ b/objdiff-core/src/arch/mips.rs
@@ -1,7 +1,10 @@
 use std::{borrow::Cow, collections::BTreeMap, sync::Mutex};
 
 use anyhow::{anyhow, bail, Result};
-use object::{elf, Endian, Endianness, File, FileFlags, Object, Relocation, RelocationFlags};
+use object::{
+    elf, Endian, Endianness, File, FileFlags, Object, ObjectSection, ObjectSymbol, Relocation,
+    RelocationFlags, RelocationTarget,
+};
 use rabbitizer::{config, Abi, InstrCategory, Instruction, OperandType};
 
 use crate::{
@@ -22,6 +25,7 @@ pub struct ObjArchMips {
     pub endianness: Endianness,
     pub abi: Abi,
     pub instr_category: InstrCategory,
+    pub ri_gp_value: i32,
 }
 
 const EF_MIPS_ABI: u32 = 0x0000F000;
@@ -56,7 +60,19 @@ impl ObjArchMips {
             }
             _ => bail!("Unsupported MIPS file flags"),
         }
-        Ok(Self { endianness: object.endianness(), abi, instr_category })
+
+        // Parse the ri_gp_value stored in .reginfo to be able to correctly
+        // calculate R_MIPS_GPREL16 relocations later. The value is stored
+        // 0x14 bytes into .reginfo (on 32 bit platforms)
+        let ri_gp_value = match object.section_by_name(".reginfo").and_then(|s| s.data().ok()) {
+            Some(reginfo) => {
+                let gp_ri_value_bytes = reginfo[0x14..0x18].try_into().unwrap_or([0u8; 4]);
+                object.endianness().read_i32_bytes(gp_ri_value_bytes)
+            }
+            None => 0,
+        };
+
+        Ok(Self { endianness: object.endianness(), abi, instr_category, ri_gp_value })
     }
 }
 
@@ -179,6 +195,7 @@ impl ObjArch for ObjArchMips {
 
     fn implcit_addend(
         &self,
+        file: &File<'_>,
         section: &ObjSection,
         address: u64,
         reloc: &Relocation,
@@ -191,9 +208,22 @@ impl ObjArch for ObjArchMips {
                 ((addend & 0x0000FFFF) << 16) as i32 as i64
             }
             RelocationFlags::Elf {
-                r_type:
-                    elf::R_MIPS_LO16 | elf::R_MIPS_GOT16 | elf::R_MIPS_CALL16 | elf::R_MIPS_GPREL16,
+                r_type: elf::R_MIPS_LO16 | elf::R_MIPS_GOT16 | elf::R_MIPS_CALL16,
             } => (addend & 0x0000FFFF) as i16 as i64,
+            RelocationFlags::Elf { r_type: elf::R_MIPS_GPREL16 } => {
+                let RelocationTarget::Symbol(idx) = reloc.target() else {
+                    bail!("Unsupported R_MIPS_GPREL16 relocation against a non-symbol");
+                };
+                let sym = file.symbol_by_index(idx)?;
+
+                // if the symbol we are relocating against is in a local section we need to add
+                // the ri_gp_value from .reginfo to the addend.
+                if sym.section().index().is_some() {
+                    ((addend & 0x0000FFFF) as i16 as i64) + self.ri_gp_value as i64
+                } else {
+                    (addend & 0x0000FFFF) as i16 as i64
+                }
+            }
             RelocationFlags::Elf { r_type: elf::R_MIPS_26 } => ((addend & 0x03FFFFFF) << 2) as i64,
             flags => bail!("Unsupported MIPS implicit relocation {flags:?}"),
         })

--- a/objdiff-core/src/arch/mips.rs
+++ b/objdiff-core/src/arch/mips.rs
@@ -64,13 +64,13 @@ impl ObjArchMips {
         // Parse the ri_gp_value stored in .reginfo to be able to correctly
         // calculate R_MIPS_GPREL16 relocations later. The value is stored
         // 0x14 bytes into .reginfo (on 32 bit platforms)
-        let ri_gp_value = match object.section_by_name(".reginfo").and_then(|s| s.data().ok()) {
-            Some(reginfo) => {
-                let gp_ri_value_bytes = reginfo[0x14..0x18].try_into().unwrap_or([0u8; 4]);
-                object.endianness().read_i32_bytes(gp_ri_value_bytes)
-            }
-            None => 0,
-        };
+        let ri_gp_value = object
+            .section_by_name(".reginfo")
+            .and_then(|section| section.data().ok())
+            .and_then(|data| data.get(0x14..0x18))
+            .and_then(|s| s.try_into().ok())
+            .map(|bytes| object.endianness().read_i32_bytes(bytes))
+            .unwrap_or(0);
 
         Ok(Self { endianness: object.endianness(), abi, instr_category, ri_gp_value })
     }

--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -36,15 +36,11 @@ pub trait ObjArch: Send + Sync {
         reloc: &Relocation,
     ) -> Result<i64>;
 
-    fn demangle(&self, _name: &str) -> Option<String> {
-        None
-    }
+    fn demangle(&self, _name: &str) -> Option<String> { None }
 
     fn display_reloc(&self, flags: RelocationFlags) -> Cow<'static, str>;
 
-    fn symbol_address(&self, symbol: &Symbol) -> u64 {
-        symbol.address()
-    }
+    fn symbol_address(&self, symbol: &Symbol) -> u64 { symbol.address() }
 }
 
 pub struct ProcessCodeResult {

--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, collections::BTreeMap};
 
 use anyhow::{bail, Result};
-use object::{Architecture, Object, ObjectSymbol, Relocation, RelocationFlags, Symbol};
+use object::{Architecture, File, Object, ObjectSymbol, Relocation, RelocationFlags, Symbol};
 
 use crate::{
     diff::DiffObjConfig,
@@ -28,14 +28,23 @@ pub trait ObjArch: Send + Sync {
         config: &DiffObjConfig,
     ) -> Result<ProcessCodeResult>;
 
-    fn implcit_addend(&self, section: &ObjSection, address: u64, reloc: &Relocation)
-        -> Result<i64>;
+    fn implcit_addend(
+        &self,
+        file: &File<'_>,
+        section: &ObjSection,
+        address: u64,
+        reloc: &Relocation,
+    ) -> Result<i64>;
 
-    fn demangle(&self, _name: &str) -> Option<String> { None }
+    fn demangle(&self, _name: &str) -> Option<String> {
+        None
+    }
 
     fn display_reloc(&self, flags: RelocationFlags) -> Cow<'static, str>;
 
-    fn symbol_address(&self, symbol: &Symbol) -> u64 { symbol.address() }
+    fn symbol_address(&self, symbol: &Symbol) -> u64 {
+        symbol.address()
+    }
 }
 
 pub struct ProcessCodeResult {

--- a/objdiff-core/src/arch/ppc.rs
+++ b/objdiff-core/src/arch/ppc.rs
@@ -20,16 +20,12 @@ fn is_rel_abs_arg(arg: &Argument) -> bool {
     matches!(arg, Argument::Uimm(_) | Argument::Simm(_) | Argument::Offset(_))
 }
 
-fn is_offset_arg(arg: &Argument) -> bool {
-    matches!(arg, Argument::Offset(_))
-}
+fn is_offset_arg(arg: &Argument) -> bool { matches!(arg, Argument::Offset(_)) }
 
 pub struct ObjArchPpc {}
 
 impl ObjArchPpc {
-    pub fn new(_file: &File) -> Result<Self> {
-        Ok(Self {})
-    }
+    pub fn new(_file: &File) -> Result<Self> { Ok(Self {}) }
 }
 
 impl ObjArch for ObjArchPpc {

--- a/objdiff-core/src/arch/ppc.rs
+++ b/objdiff-core/src/arch/ppc.rs
@@ -20,12 +20,16 @@ fn is_rel_abs_arg(arg: &Argument) -> bool {
     matches!(arg, Argument::Uimm(_) | Argument::Simm(_) | Argument::Offset(_))
 }
 
-fn is_offset_arg(arg: &Argument) -> bool { matches!(arg, Argument::Offset(_)) }
+fn is_offset_arg(arg: &Argument) -> bool {
+    matches!(arg, Argument::Offset(_))
+}
 
 pub struct ObjArchPpc {}
 
 impl ObjArchPpc {
-    pub fn new(_file: &File) -> Result<Self> { Ok(Self {}) }
+    pub fn new(_file: &File) -> Result<Self> {
+        Ok(Self {})
+    }
 }
 
 impl ObjArch for ObjArchPpc {
@@ -150,6 +154,7 @@ impl ObjArch for ObjArchPpc {
 
     fn implcit_addend(
         &self,
+        _file: &File<'_>,
         _section: &ObjSection,
         address: u64,
         reloc: &Relocation,

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -128,6 +128,7 @@ impl ObjArch for ObjArchX86 {
 
     fn implcit_addend(
         &self,
+        _file: &File<'_>,
         section: &ObjSection,
         address: u64,
         reloc: &Relocation,
@@ -261,9 +262,12 @@ impl FormatterOutput for InstructionFormatterOutput {
         match kind {
             FormatterTextKind::LabelAddress => {
                 if let Some(reloc) = self.ins.reloc.as_ref() {
-                    if matches!(reloc.flags, RelocationFlags::Coff {
-                        typ: pe::IMAGE_REL_I386_DIR32 | pe::IMAGE_REL_I386_REL32
-                    }) {
+                    if matches!(
+                        reloc.flags,
+                        RelocationFlags::Coff {
+                            typ: pe::IMAGE_REL_I386_DIR32 | pe::IMAGE_REL_I386_REL32
+                        }
+                    ) {
                         self.ins.args.push(ObjInsArg::Reloc);
                         return;
                     } else if self.error.is_none() {
@@ -279,9 +283,10 @@ impl FormatterOutput for InstructionFormatterOutput {
             }
             FormatterTextKind::FunctionAddress => {
                 if let Some(reloc) = self.ins.reloc.as_ref() {
-                    if matches!(reloc.flags, RelocationFlags::Coff {
-                        typ: pe::IMAGE_REL_I386_REL32
-                    }) {
+                    if matches!(
+                        reloc.flags,
+                        RelocationFlags::Coff { typ: pe::IMAGE_REL_I386_REL32 }
+                    ) {
                         self.ins.args.push(ObjInsArg::Reloc);
                         return;
                     } else if self.error.is_none() {

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -262,12 +262,9 @@ impl FormatterOutput for InstructionFormatterOutput {
         match kind {
             FormatterTextKind::LabelAddress => {
                 if let Some(reloc) = self.ins.reloc.as_ref() {
-                    if matches!(
-                        reloc.flags,
-                        RelocationFlags::Coff {
-                            typ: pe::IMAGE_REL_I386_DIR32 | pe::IMAGE_REL_I386_REL32
-                        }
-                    ) {
+                    if matches!(reloc.flags, RelocationFlags::Coff {
+                        typ: pe::IMAGE_REL_I386_DIR32 | pe::IMAGE_REL_I386_REL32
+                    }) {
                         self.ins.args.push(ObjInsArg::Reloc);
                         return;
                     } else if self.error.is_none() {
@@ -283,10 +280,9 @@ impl FormatterOutput for InstructionFormatterOutput {
             }
             FormatterTextKind::FunctionAddress => {
                 if let Some(reloc) = self.ins.reloc.as_ref() {
-                    if matches!(
-                        reloc.flags,
-                        RelocationFlags::Coff { typ: pe::IMAGE_REL_I386_REL32 }
-                    ) {
+                    if matches!(reloc.flags, RelocationFlags::Coff {
+                        typ: pe::IMAGE_REL_I386_REL32
+                    }) {
                         self.ins.args.push(ObjInsArg::Reloc);
                         return;
                     } else if self.error.is_none() {

--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -364,7 +364,7 @@ fn relocations_by_section(
             _ => None,
         };
         let addend = if reloc.has_implicit_addend() {
-            arch.implcit_addend(section, address, &reloc)?
+            arch.implcit_addend(obj_file, section, address, &reloc)?
         } else {
             reloc.addend()
         };


### PR DESCRIPTION
Discussed in discord.

synopsis: objdiff does not currently read the `ri_gp_value` field from the `.reginfo` header for MIPS objects, which is required to calculate `R_MIPS_GPREL16` relocations for local symbols.

This PR attempts to correct that. Passing the file to `implicit_addend` is required to determine whether the symbol being relocated against is local or not.