### PR TITLE
Bump unarm to 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4540,9 +4540,9 @@ dependencies = [
 
 [[package]]
 name = "unarm"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379762d9433a2e6e498cde97801fb238318b024a513d0843eeac98b9056b9f3c"
+checksum = "e82790df6bdacbe2661a9ea0e075d1aefe18198420afaa0662cef93b580c3b26"
 
 [[package]]
 name = "unicase"

--- a/objdiff-core/Cargo.toml
+++ b/objdiff-core/Cargo.toml
@@ -67,7 +67,7 @@ iced-x86 = { version = "1.21.0", default-features = false, features = ["std", "d
 msvc-demangler = { version = "0.10.0", optional = true }
 
 # arm
-unarm = { version = "1.4.0", optional = true }
+unarm = { version = "1.5.0", optional = true }
 arm-attr = { version = "0.1.1", optional = true }
 
 [build-dependencies]


### PR DESCRIPTION
unarm 1.5.0 fixes some erroneous instructions, including prioritizing LDRSB/LDRH/LDRSH over CMP (they have very similar bit patterns) and allowing backwards branches on Thumb (my apologies to GBA devs). See other changes at https://github.com/AetiasHax/unarm/pull/5.