### PR TITLE
Add 32-bit windows objdiff-cli build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -203,10 +203,6 @@ jobs:
             target: x86_64-pc-windows-msvc
             name: windows-x86_64
             features: default
-          - platform: windows-latest
-            target: i686-pc-windows-msvc
-            name: windows-x86
-            features: default
           - platform: macos-latest
             target: x86_64-apple-darwin
             name: macos-x86_64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -143,6 +143,11 @@ jobs:
             build: zigbuild
             features: default
           - platform: windows-latest
+            target: i686-pc-windows-msvc
+            name: windows-x86
+            build: build
+            features: default
+          - platform: windows-latest
             target: x86_64-pc-windows-msvc
             name: windows-x86_64
             build: build


### PR DESCRIPTION
So, I'm an idiot. I was mostly after a 32-bit win32 objdiff-cli build, but thought (in my previous PR) that the CLI and GUI were built as part of the same step. Oops.