### PR TITLE
Disambiguate dummy symbols

### DIFF
--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -644,7 +644,7 @@ pub fn parse(data: &[u8], config: &DiffObjConfig) -> Result<ObjInfo> {
         for symbol in section.symbols.iter_mut().rev() {
             if name_counts[&symbol.name] > 1 {
                 name_counts.entry(symbol.name.clone()).and_modify(|i| *i -= 1);
-                symbol.name = format!("{} {}", &symbol.name, name_counts[&symbol.name]);
+                symbol.name = format!("{} ({})", &symbol.name, name_counts[&symbol.name]);
             }
         }
     }


### PR DESCRIPTION
This makes the dummy symbols diffable even if there is more than one. I am aware that this could be considered a hacky fix, but it does do its job. 