### PR TITLE
PPC: Guess reloc data type based on the instruction.

### DIFF
--- a/objdiff-core/src/obj/mod.rs
+++ b/objdiff-core/src/obj/mod.rs
@@ -126,6 +126,7 @@ pub struct ObjSymbol {
     pub virtual_address: Option<u64>,
     /// Original index in object symbol table
     pub original_index: Option<usize>,
+    pub bytes: Vec<u8>,
 }
 
 pub struct ObjInfo {

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -80,7 +80,7 @@ fn ins_hover_ui(
                     format!("Size: {:x}", reloc.target.size),
                 );
                 if let Some(s) = arch
-                    .guess_data_type(&ins)
+                    .guess_data_type(ins)
                     .and_then(|ty| arch.display_data_type(ty, &reloc.target.bytes))
                 {
                     ui.colored_label(appearance.highlight_color, s);

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -79,6 +79,12 @@ fn ins_hover_ui(
                     appearance.highlight_color,
                     format!("Size: {:x}", reloc.target.size),
                 );
+                if let Some(s) = arch
+                    .guess_data_type(&ins)
+                    .and_then(|ty| arch.display_data_type(ty, &reloc.target.bytes))
+                {
+                    ui.colored_label(appearance.highlight_color, s);
+                }
             } else {
                 ui.colored_label(appearance.highlight_color, "Extern".to_string());
             }


### PR DESCRIPTION
Adds an entry to the reloc tooltip to show the inferred data type and value.

This is potentially somewhat rough. I'm opening this get early feedback on the implementation. If this is deemed acceptable as is, it currently only implements PowerPC and I would be planning to follow up with a similar implementation for MIPS. I would also like to followup with an extension to the right-click context menu to copy the value of a reloc.
For integers: Unsigned and Signed interpretations are displayed (signed is only shown when value would be negative)

Arguably the string display should be removed as it may be somewhat confusing that it doesn't necessarily correspond to the string being used by the code.

Images:
![image](https://github.com/user-attachments/assets/d1327338-2c81-4f5b-9e23-715276075ec4)
![image](https://github.com/user-attachments/assets/6bf2f698-67bb-413b-9ecc-1dea14678cb7)
![image](https://github.com/user-attachments/assets/a846169d-3d94-42e8-9cd6-2a6a59f99cbd)
![image](https://github.com/user-attachments/assets/d2bfb812-78e3-4c30-a360-40f9dc03b4de)
![image](https://github.com/user-attachments/assets/79fcf35b-484d-4af9-a9fb-41e77abbea3a)
![image](https://github.com/user-attachments/assets/c37db5c6-db90-40ba-bb4b-ce96cc61486f)
