### PR TITLE
Add symbol mapping feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2852,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "objdiff-cli"
-version = "2.2.2"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "argp",
@@ -2874,10 +2883,11 @@ dependencies = [
 
 [[package]]
 name = "objdiff-core"
-version = "2.2.2"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "arm-attr",
+ "bimap",
  "byteorder",
  "console_error_panic_hook",
  "console_log",
@@ -2913,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "objdiff-gui"
-version = "2.2.2"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ strip = "debuginfo"
 codegen-units = 1
 
 [workspace.package]
-version = "2.2.2"
+version = "2.3.0"
 authors = ["Luke Street <luke@street.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/config.schema.json
+++ b/config.schema.json
@@ -133,6 +133,13 @@
         },
         "metadata": {
           "ref": "#/$defs/metadata"
+        },
+        "symbol_mappings": {
+          "type": "object",
+          "description": "Manual symbol mappings from target to base.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       }
     },

--- a/objdiff-cli/src/cmd/diff.rs
+++ b/objdiff-cli/src/cmd/diff.rs
@@ -102,26 +102,32 @@ pub fn run(args: Args) -> Result<()> {
                     let unit_path =
                         PathBuf::from_str(u).ok().and_then(|p| fs::canonicalize(p).ok());
 
-                    let Some(object) = project_config.objects.iter_mut().find_map(|obj| {
-                        if obj.name.as_deref() == Some(u) {
+                    let Some(object) = project_config
+                        .units
+                        .as_deref_mut()
+                        .unwrap_or_default()
+                        .iter_mut()
+                        .find_map(|obj| {
+                            if obj.name.as_deref() == Some(u) {
+                                resolve_paths(obj);
+                                return Some(obj);
+                            }
+
+                            let up = unit_path.as_deref()?;
+
                             resolve_paths(obj);
-                            return Some(obj);
-                        }
 
-                        let up = unit_path.as_deref()?;
+                            if [&obj.base_path, &obj.target_path]
+                                .into_iter()
+                                .filter_map(|p| p.as_ref().and_then(|p| p.canonicalize().ok()))
+                                .any(|p| p == up)
+                            {
+                                return Some(obj);
+                            }
 
-                        resolve_paths(obj);
-
-                        if [&obj.base_path, &obj.target_path]
-                            .into_iter()
-                            .filter_map(|p| p.as_ref().and_then(|p| p.canonicalize().ok()))
-                            .any(|p| p == up)
-                        {
-                            return Some(obj);
-                        }
-
-                        None
-                    }) else {
+                            None
+                        })
+                    else {
                         bail!("Unit not found: {}", u)
                     };
 
@@ -129,7 +135,13 @@ pub fn run(args: Args) -> Result<()> {
                 } else if let Some(symbol_name) = &args.symbol {
                     let mut idx = None;
                     let mut count = 0usize;
-                    for (i, obj) in project_config.objects.iter_mut().enumerate() {
+                    for (i, obj) in project_config
+                        .units
+                        .as_deref_mut()
+                        .unwrap_or_default()
+                        .iter_mut()
+                        .enumerate()
+                    {
                         resolve_paths(obj);
 
                         if obj
@@ -148,7 +160,7 @@ pub fn run(args: Args) -> Result<()> {
                     }
                     match (count, idx) {
                         (0, None) => bail!("Symbol not found: {}", symbol_name),
-                        (1, Some(i)) => &mut project_config.objects[i],
+                        (1, Some(i)) => &mut project_config.units_mut()[i],
                         (2.., Some(_)) => bail!(
                             "Multiple instances of {} were found, try specifying a unit",
                             symbol_name

--- a/objdiff-cli/src/cmd/diff.rs
+++ b/objdiff-cli/src/cmd/diff.rs
@@ -303,7 +303,7 @@ fn find_function(obj: &ObjInfo, name: &str) -> Option<SymbolRef> {
     None
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct FunctionDiffUi {
     relax_reloc_diffs: bool,
     left_highlight: HighlightKind,
@@ -758,7 +758,7 @@ impl FunctionDiffUi {
         self.scroll_y += self.per_page / if half { 2 } else { 1 };
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn print_sym(
         &self,
         out: &mut Text<'static>,

--- a/objdiff-cli/src/cmd/report.rs
+++ b/objdiff-cli/src/cmd/report.rs
@@ -94,7 +94,7 @@ fn generate(args: GenerateArgs) -> Result<()> {
     };
     info!(
         "Generating report for {} units (using {} threads)",
-        project.objects.len(),
+        project.units().len(),
         if args.deduplicate { 1 } else { rayon::current_num_threads() }
     );
 
@@ -103,7 +103,7 @@ fn generate(args: GenerateArgs) -> Result<()> {
     let mut existing_functions: HashSet<String> = HashSet::new();
     if args.deduplicate {
         // If deduplicating, we need to run single-threaded
-        for object in &mut project.objects {
+        for object in project.units.as_deref_mut().unwrap_or_default() {
             if let Some(unit) = report_object(
                 object,
                 project_dir,
@@ -116,7 +116,9 @@ fn generate(args: GenerateArgs) -> Result<()> {
         }
     } else {
         let vec = project
-            .objects
+            .units
+            .as_deref_mut()
+            .unwrap_or_default()
             .par_iter_mut()
             .map(|object| {
                 report_object(
@@ -132,7 +134,7 @@ fn generate(args: GenerateArgs) -> Result<()> {
     }
     let measures = units.iter().flat_map(|u| u.measures.into_iter()).collect();
     let mut categories = Vec::new();
-    for category in &project.progress_categories {
+    for category in project.progress_categories() {
         categories.push(ReportCategory {
             id: category.id.clone(),
             name: category.name.clone(),

--- a/objdiff-core/Cargo.toml
+++ b/objdiff-core/Cargo.toml
@@ -17,8 +17,8 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 all = ["config", "dwarf", "mips", "ppc", "x86", "arm", "bindings"]
-any-arch = [] # Implicit, used to check if any arch is enabled
-config = ["globset", "semver", "serde_json", "serde_yaml"]
+any-arch = ["bimap"] # Implicit, used to check if any arch is enabled
+config = ["bimap", "globset", "semver", "serde_json", "serde_yaml"]
 dwarf = ["gimli"]
 mips = ["any-arch", "rabbitizer"]
 ppc = ["any-arch", "cwdemangle", "cwextab", "ppc750cl"]
@@ -32,6 +32,7 @@ features = ["all"]
 
 [dependencies]
 anyhow = "1.0"
+bimap = { version = "0.6", features = ["serde"], optional = true }
 byteorder = "1.5"
 filetime = "0.2"
 flagset = "0.4"

--- a/objdiff-core/src/config/mod.rs
+++ b/objdiff-core/src/config/mod.rs
@@ -112,12 +112,12 @@ impl ProjectObject {
     }
 
     pub fn complete(&self) -> Option<bool> {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         self.metadata.as_ref().and_then(|m| m.complete).or(self.complete)
     }
 
     pub fn reverse_fn_order(&self) -> Option<bool> {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         self.metadata.as_ref().and_then(|m| m.reverse_fn_order).or(self.reverse_fn_order)
     }
 

--- a/objdiff-core/src/config/mod.rs
+++ b/objdiff-core/src/config/mod.rs
@@ -1,77 +1,100 @@
 use std::{
+    fs,
     fs::File,
-    io::{BufReader, Read},
+    io::{BufReader, BufWriter, Read},
     path::{Path, PathBuf},
 };
 
 use anyhow::{anyhow, Context, Result};
+use bimap::BiBTreeMap;
 use filetime::FileTime;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
-#[inline]
-fn bool_true() -> bool { true }
-
-#[derive(Default, Clone, serde::Deserialize)]
+#[derive(Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProjectConfig {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min_version: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_make: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_args: Option<Vec<String>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_dir: Option<PathBuf>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_dir: Option<PathBuf>,
-    #[serde(default = "bool_true")]
-    pub build_base: bool,
-    #[serde(default)]
-    pub build_target: bool,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_base: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_target: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub watch_patterns: Option<Vec<Glob>>,
-    #[serde(default, alias = "units")]
-    pub objects: Vec<ProjectObject>,
-    #[serde(default)]
-    pub progress_categories: Vec<ProjectProgressCategory>,
+    #[serde(default, alias = "objects", skip_serializing_if = "Option::is_none")]
+    pub units: Option<Vec<ProjectObject>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub progress_categories: Option<Vec<ProjectProgressCategory>>,
 }
 
-#[derive(Default, Clone, serde::Deserialize)]
+impl ProjectConfig {
+    #[inline]
+    pub fn units(&self) -> &[ProjectObject] { self.units.as_deref().unwrap_or_default() }
+
+    #[inline]
+    pub fn units_mut(&mut self) -> &mut Vec<ProjectObject> {
+        self.units.get_or_insert_with(Vec::new)
+    }
+
+    #[inline]
+    pub fn progress_categories(&self) -> &[ProjectProgressCategory] {
+        self.progress_categories.as_deref().unwrap_or_default()
+    }
+
+    #[inline]
+    pub fn progress_categories_mut(&mut self) -> &mut Vec<ProjectProgressCategory> {
+        self.progress_categories.get_or_insert_with(Vec::new)
+    }
+}
+
+#[derive(Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProjectObject {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_path: Option<PathBuf>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_path: Option<PathBuf>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[deprecated(note = "Use metadata.reverse_fn_order")]
     pub reverse_fn_order: Option<bool>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[deprecated(note = "Use metadata.complete")]
     pub complete: Option<bool>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scratch: Option<ScratchConfig>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<ProjectObjectMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbol_mappings: Option<SymbolMappings>,
 }
 
-#[derive(Default, Clone, serde::Deserialize)]
+pub type SymbolMappings = BiBTreeMap<String, String>;
+
+#[derive(Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProjectObjectMetadata {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub complete: Option<bool>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reverse_fn_order: Option<bool>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_path: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub progress_categories: Option<Vec<String>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_generated: Option<bool>,
 }
 
-#[derive(Default, Clone, serde::Deserialize)]
+#[derive(Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProjectProgressCategory {
     #[serde(default)]
     pub id: String,
@@ -132,16 +155,16 @@ impl ProjectObject {
 
 #[derive(Default, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ScratchConfig {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub platform: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compiler: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub c_flags: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ctx_path: Option<PathBuf>,
-    #[serde(default)]
-    pub build_ctx: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_ctx: Option<bool>,
 }
 
 pub const CONFIG_FILENAMES: [&str; 3] = ["objdiff.json", "objdiff.yml", "objdiff.yaml"];
@@ -154,7 +177,7 @@ pub const DEFAULT_WATCH_PATTERNS: &[&str] = &[
 #[derive(Clone, Eq, PartialEq)]
 pub struct ProjectConfigInfo {
     pub path: PathBuf,
-    pub timestamp: FileTime,
+    pub timestamp: Option<FileTime>,
 }
 
 pub fn try_project_config(dir: &Path) -> Option<(Result<ProjectConfig>, ProjectConfigInfo)> {
@@ -180,10 +203,39 @@ pub fn try_project_config(dir: &Path) -> Option<(Result<ProjectConfig>, ProjectC
                     result = Err(e);
                 }
             }
-            return Some((result, ProjectConfigInfo { path: config_path, timestamp: ts }));
+            return Some((result, ProjectConfigInfo { path: config_path, timestamp: Some(ts) }));
         }
     }
     None
+}
+
+pub fn save_project_config(
+    config: &ProjectConfig,
+    info: &ProjectConfigInfo,
+) -> Result<ProjectConfigInfo> {
+    if let Some(last_ts) = info.timestamp {
+        // Check if the file has changed since we last read it
+        if let Ok(metadata) = fs::metadata(&info.path) {
+            let ts = FileTime::from_last_modification_time(&metadata);
+            if ts != last_ts {
+                return Err(anyhow!("Config file has changed since last read"));
+            }
+        }
+    }
+    let mut writer =
+        BufWriter::new(File::create(&info.path).context("Failed to create config file")?);
+    let ext = info.path.extension().and_then(|ext| ext.to_str()).unwrap_or("json");
+    match ext {
+        "json" => serde_json::to_writer_pretty(&mut writer, config).context("Failed to write JSON"),
+        "yml" | "yaml" => {
+            serde_yaml::to_writer(&mut writer, config).context("Failed to write YAML")
+        }
+        _ => Err(anyhow!("Unknown config file extension: {ext}")),
+    }?;
+    let file = writer.into_inner().context("Failed to flush file")?;
+    let metadata = file.metadata().context("Failed to get file metadata")?;
+    let ts = FileTime::from_last_modification_time(&metadata);
+    Ok(ProjectConfigInfo { path: info.path.clone(), timestamp: Some(ts) })
 }
 
 fn validate_min_version(config: &ProjectConfig) -> Result<()> {

--- a/objdiff-core/src/diff/code.rs
+++ b/objdiff-core/src/diff/code.rs
@@ -41,7 +41,7 @@ pub fn no_diff_code(out: &ProcessCodeResult, symbol_ref: SymbolRef) -> Result<Ob
         });
     }
     resolve_branches(&mut diff);
-    Ok(ObjSymbolDiff { symbol_ref, diff_symbol: None, instructions: diff, match_percent: None })
+    Ok(ObjSymbolDiff { symbol_ref, target_symbol: None, instructions: diff, match_percent: None })
 }
 
 pub fn diff_code(
@@ -67,7 +67,7 @@ pub fn diff_code(
         right.arg_diff = result.right_args_diff;
     }
 
-    let total = left_out.insts.len();
+    let total = left_out.insts.len().max(right_out.insts.len());
     let percent = if diff_state.diff_count >= total {
         0.0
     } else {
@@ -77,13 +77,13 @@ pub fn diff_code(
     Ok((
         ObjSymbolDiff {
             symbol_ref: left_symbol_ref,
-            diff_symbol: Some(right_symbol_ref),
+            target_symbol: Some(right_symbol_ref),
             instructions: left_diff,
             match_percent: Some(percent),
         },
         ObjSymbolDiff {
             symbol_ref: right_symbol_ref,
-            diff_symbol: Some(left_symbol_ref),
+            target_symbol: Some(left_symbol_ref),
             instructions: right_diff,
             match_percent: Some(percent),
         },

--- a/objdiff-core/src/diff/code.rs
+++ b/objdiff-core/src/diff/code.rs
@@ -211,7 +211,7 @@ fn arg_eq(
     left_diff: &ObjInsDiff,
     right_diff: &ObjInsDiff,
 ) -> bool {
-    return match left {
+    match left {
         ObjInsArg::PlainText(l) => match right {
             ObjInsArg::PlainText(r) => l == r,
             _ => false,
@@ -236,7 +236,7 @@ fn arg_eq(
             left_diff.branch_to.as_ref().map(|b| b.ins_idx)
                 == right_diff.branch_to.as_ref().map(|b| b.ins_idx)
         }
-    };
+    }
 }
 
 #[derive(Default)]

--- a/objdiff-core/src/diff/data.rs
+++ b/objdiff-core/src/diff/data.rs
@@ -20,13 +20,13 @@ pub fn diff_bss_symbol(
     Ok((
         ObjSymbolDiff {
             symbol_ref: left_symbol_ref,
-            diff_symbol: Some(right_symbol_ref),
+            target_symbol: Some(right_symbol_ref),
             instructions: vec![],
             match_percent: Some(percent),
         },
         ObjSymbolDiff {
             symbol_ref: right_symbol_ref,
-            diff_symbol: Some(left_symbol_ref),
+            target_symbol: Some(left_symbol_ref),
             instructions: vec![],
             match_percent: Some(percent),
         },
@@ -34,7 +34,7 @@ pub fn diff_bss_symbol(
 }
 
 pub fn no_diff_symbol(_obj: &ObjInfo, symbol_ref: SymbolRef) -> ObjSymbolDiff {
-    ObjSymbolDiff { symbol_ref, diff_symbol: None, instructions: vec![], match_percent: None }
+    ObjSymbolDiff { symbol_ref, target_symbol: None, instructions: vec![], match_percent: None }
 }
 
 /// Compare the data sections of two object files.
@@ -158,13 +158,13 @@ pub fn diff_data_symbol(
     Ok((
         ObjSymbolDiff {
             symbol_ref: left_symbol_ref,
-            diff_symbol: Some(right_symbol_ref),
+            target_symbol: Some(right_symbol_ref),
             instructions: vec![],
             match_percent: Some(match_percent),
         },
         ObjSymbolDiff {
             symbol_ref: right_symbol_ref,
-            diff_symbol: Some(left_symbol_ref),
+            target_symbol: Some(left_symbol_ref),
             instructions: vec![],
             match_percent: Some(match_percent),
         },

--- a/objdiff-core/src/diff/display.rs
+++ b/objdiff-core/src/diff/display.rs
@@ -29,7 +29,7 @@ pub enum DiffText<'a> {
     Eol,
 }
 
-#[derive(Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub enum HighlightKind {
     #[default]
     None,

--- a/objdiff-core/src/diff/mod.rs
+++ b/objdiff-core/src/diff/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use anyhow::Result;
 
 use crate::{
+    config::SymbolMappings,
     diff::{
         code::{diff_code, no_diff_code, process_code_symbol},
         data::{
@@ -161,7 +162,8 @@ pub struct DiffObjConfig {
     #[serde(default = "default_true")]
     pub space_between_args: bool,
     pub combine_data_sections: bool,
-    pub symbol_overrides: SymbolOverrides,
+    #[serde(default)]
+    pub symbol_mappings: MappingConfig,
     // x86
     pub x86_formatter: X86Formatter,
     // MIPS
@@ -183,7 +185,7 @@ impl Default for DiffObjConfig {
             relax_reloc_diffs: false,
             space_between_args: true,
             combine_data_sections: false,
-            symbol_overrides: Default::default(),
+            symbol_mappings: Default::default(),
             x86_formatter: Default::default(),
             mips_abi: Default::default(),
             mips_instr_category: Default::default(),
@@ -225,8 +227,10 @@ impl ObjSectionDiff {
 
 #[derive(Debug, Clone, Default)]
 pub struct ObjSymbolDiff {
+    /// The symbol ref this object
     pub symbol_ref: SymbolRef,
-    pub diff_symbol: Option<SymbolRef>,
+    /// The symbol ref in the _other_ object that this symbol was diffed against
+    pub target_symbol: Option<SymbolRef>,
     pub instructions: Vec<ObjInsDiff>,
     pub match_percent: Option<f32>,
 }
@@ -296,8 +300,13 @@ pub struct ObjInsBranchTo {
 
 #[derive(Default)]
 pub struct ObjDiff {
+    /// A list of all section diffs in the object.
     pub sections: Vec<ObjSectionDiff>,
+    /// Common BSS symbols don't live in a section, so they're stored separately.
     pub common: Vec<ObjSymbolDiff>,
+    /// If `selecting_left` or `selecting_right` is set, this is the list of symbols
+    /// that are being mapped to the other object.
+    pub mapping_symbols: Vec<ObjSymbolDiff>,
 }
 
 impl ObjDiff {
@@ -305,13 +314,14 @@ impl ObjDiff {
         let mut result = Self {
             sections: Vec::with_capacity(obj.sections.len()),
             common: Vec::with_capacity(obj.common.len()),
+            mapping_symbols: vec![],
         };
         for (section_idx, section) in obj.sections.iter().enumerate() {
             let mut symbols = Vec::with_capacity(section.symbols.len());
             for (symbol_idx, _) in section.symbols.iter().enumerate() {
                 symbols.push(ObjSymbolDiff {
                     symbol_ref: SymbolRef { section_idx, symbol_idx },
-                    diff_symbol: None,
+                    target_symbol: None,
                     instructions: vec![],
                     match_percent: None,
                 });
@@ -330,7 +340,7 @@ impl ObjDiff {
         for (symbol_idx, _) in obj.common.iter().enumerate() {
             result.common.push(ObjSymbolDiff {
                 symbol_ref: SymbolRef { section_idx: obj.sections.len(), symbol_idx },
-                diff_symbol: None,
+                target_symbol: None,
                 instructions: vec![],
                 match_percent: None,
             });
@@ -380,7 +390,7 @@ pub fn diff_objs(
     right: Option<&ObjInfo>,
     prev: Option<&ObjInfo>,
 ) -> Result<DiffObjsResult> {
-    let symbol_matches = matching_symbols(left, right, prev, &config.symbol_overrides)?;
+    let symbol_matches = matching_symbols(left, right, prev, &config.symbol_mappings)?;
     let section_matches = matching_sections(left, right)?;
     let mut left = left.map(|p| (p, ObjDiff::new_from_obj(p)));
     let mut right = right.map(|p| (p, ObjDiff::new_from_obj(p)));
@@ -531,11 +541,79 @@ pub fn diff_objs(
         }
     }
 
+    if let (Some((right_obj, right_out)), Some((left_obj, left_out))) =
+        (right.as_mut(), left.as_mut())
+    {
+        if let Some(right_name) = &config.symbol_mappings.selecting_left {
+            generate_mapping_symbols(right_obj, right_name, left_obj, left_out, config)?;
+        }
+        if let Some(left_name) = &config.symbol_mappings.selecting_right {
+            generate_mapping_symbols(left_obj, left_name, right_obj, right_out, config)?;
+        }
+    }
+
     Ok(DiffObjsResult {
         left: left.map(|(_, o)| o),
         right: right.map(|(_, o)| o),
         prev: prev.map(|(_, o)| o),
     })
+}
+
+/// When we're selecting a symbol to use as a comparison, we'll create comparisons for all
+/// symbols in the other object that match the selected symbol's section and kind. This allows
+/// us to display match percentages for all symbols in the other object that could be selected.
+fn generate_mapping_symbols(
+    base_obj: &ObjInfo,
+    base_name: &str,
+    target_obj: &ObjInfo,
+    target_out: &mut ObjDiff,
+    config: &DiffObjConfig,
+) -> Result<()> {
+    let Some(base_symbol_ref) = symbol_ref_by_name(base_obj, base_name) else {
+        return Ok(());
+    };
+    let (base_section, base_symbol) = base_obj.section_symbol(base_symbol_ref);
+    let Some(base_section) = base_section else {
+        return Ok(());
+    };
+    let base_code = match base_section.kind {
+        ObjSectionKind::Code => Some(process_code_symbol(base_obj, base_symbol_ref, config)?),
+        _ => None,
+    };
+    for (target_section_index, target_section) in
+        target_obj.sections.iter().enumerate().filter(|(_, s)| s.kind == base_section.kind)
+    {
+        for (target_symbol_index, _target_symbol) in
+            target_section.symbols.iter().enumerate().filter(|(_, s)| s.kind == base_symbol.kind)
+        {
+            let target_symbol_ref =
+                SymbolRef { section_idx: target_section_index, symbol_idx: target_symbol_index };
+            match base_section.kind {
+                ObjSectionKind::Code => {
+                    let target_code = process_code_symbol(target_obj, target_symbol_ref, config)?;
+                    let (left_diff, _right_diff) = diff_code(
+                        &target_code,
+                        base_code.as_ref().unwrap(),
+                        target_symbol_ref,
+                        base_symbol_ref,
+                        config,
+                    )?;
+                    target_out.mapping_symbols.push(left_diff);
+                }
+                ObjSectionKind::Data => {
+                    let (left_diff, _right_diff) =
+                        diff_data_symbol(target_obj, base_obj, target_symbol_ref, base_symbol_ref)?;
+                    target_out.mapping_symbols.push(left_diff);
+                }
+                ObjSectionKind::Bss => {
+                    let (left_diff, _right_diff) =
+                        diff_bss_symbol(target_obj, base_obj, target_symbol_ref, base_symbol_ref)?;
+                    target_out.mapping_symbols.push(left_diff);
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -554,52 +632,83 @@ struct SectionMatch {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, serde::Deserialize, serde::Serialize)]
-pub struct SymbolOverride {
-    pub left: Option<String>,
-    pub right: Option<String>,
+pub struct MappingConfig {
+    /// Manual symbol mappings
+    pub mappings: SymbolMappings,
+    /// The right object symbol name that we're selecting a left symbol for
+    pub selecting_left: Option<String>,
+    /// The left object symbol name that we're selecting a right symbol for
+    pub selecting_right: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, serde::Deserialize, serde::Serialize)]
-pub struct SymbolOverrides(pub Vec<SymbolOverride>);
-
-impl SymbolOverrides {
-    pub fn get(&self, name: &str) -> Option<&SymbolOverride> {
-        self.0.iter().find(|o| {
-            o.left.as_ref().is_some_and(|l| l == name)
-                || o.right.as_ref().is_some_and(|r| r == name)
-        })
-    }
-
-    pub fn remove_left(&mut self, left: &str, right: &str) {
-        self.0.retain(|o| {
-            o.left.as_ref().map_or(true, |l| l != left)
-                && o.right.as_ref().map_or(true, |r| r != right)
-        });
-        self.0.push(SymbolOverride { left: None, right: Some(right.to_string()) });
-        // println!("{:?}", self.0);
-    }
-
-    pub fn remove_right(&mut self, left: &str, right: &str) {
-        self.0.retain(|o| {
-            o.left.as_ref().map_or(true, |l| l != left)
-                && o.right.as_ref().map_or(true, |r| r != right)
-        });
-        self.0.push(SymbolOverride { left: Some(left.to_string()), right: None });
-        // println!("{:?}", self.0);
-    }
-
-    pub fn set(&mut self, left: String, right: String) {
-        self.0.retain(|o| {
-            o.left.as_ref().map_or(true, |l| l != &left && l != &right)
-                && o.right.as_ref().map_or(true, |r| r != &left && r != &right)
-        });
-        if left != right {
-            self.0.push(SymbolOverride { left: Some(left), right: Some(right) });
+fn symbol_ref_by_name(obj: &ObjInfo, name: &str) -> Option<SymbolRef> {
+    for (section_idx, section) in obj.sections.iter().enumerate() {
+        for (symbol_idx, symbol) in section.symbols.iter().enumerate() {
+            if symbol.name == name {
+                return Some(SymbolRef { section_idx, symbol_idx });
+            }
         }
-        // println!("{:?}", self.0);
+    }
+    None
+}
+
+fn apply_symbol_mappings(
+    left: &ObjInfo,
+    right: &ObjInfo,
+    mapping_config: &MappingConfig,
+    left_used: &mut HashSet<SymbolRef>,
+    right_used: &mut HashSet<SymbolRef>,
+    matches: &mut Vec<SymbolMatch>,
+) -> Result<()> {
+    // If we're selecting a symbol to use as a comparison, mark it as used
+    // This ensures that we don't match it to another symbol at any point
+    if let Some(left_name) = &mapping_config.selecting_left {
+        if let Some(left_symbol) = symbol_ref_by_name(left, left_name) {
+            left_used.insert(left_symbol);
+        }
+    }
+    if let Some(right_name) = &mapping_config.selecting_right {
+        if let Some(right_symbol) = symbol_ref_by_name(right, right_name) {
+            right_used.insert(right_symbol);
+        }
     }
 
-    pub fn clear(&mut self) { self.0.clear(); }
+    // Apply manual symbol mappings
+    for (left_name, right_name) in &mapping_config.mappings {
+        let Some(left_symbol) = symbol_ref_by_name(left, left_name) else {
+            continue;
+        };
+        if left_used.contains(&left_symbol) {
+            continue;
+        }
+        let Some(right_symbol) = symbol_ref_by_name(right, right_name) else {
+            continue;
+        };
+        if right_used.contains(&right_symbol) {
+            continue;
+        }
+        let left_section = &left.sections[left_symbol.section_idx];
+        let right_section = &right.sections[right_symbol.section_idx];
+        if left_section.kind != right_section.kind {
+            log::warn!(
+                "Symbol section kind mismatch: {} ({:?}) vs {} ({:?})",
+                left_name,
+                left_section.kind,
+                right_name,
+                right_section.kind
+            );
+            continue;
+        }
+        matches.push(SymbolMatch {
+            left: Some(left_symbol),
+            right: Some(right_symbol),
+            prev: None, // TODO
+            section_kind: left_section.kind,
+        });
+        left_used.insert(left_symbol);
+        right_used.insert(right_symbol);
+    }
+    Ok(())
 }
 
 /// Find matching symbols between each object.
@@ -607,17 +716,32 @@ fn matching_symbols(
     left: Option<&ObjInfo>,
     right: Option<&ObjInfo>,
     prev: Option<&ObjInfo>,
-    overrides: &SymbolOverrides,
+    mappings: &MappingConfig,
 ) -> Result<Vec<SymbolMatch>> {
     let mut matches = Vec::new();
+    let mut left_used = HashSet::new();
     let mut right_used = HashSet::new();
     if let Some(left) = left {
+        if let Some(right) = right {
+            apply_symbol_mappings(
+                left,
+                right,
+                mappings,
+                &mut left_used,
+                &mut right_used,
+                &mut matches,
+            )?;
+        }
         for (section_idx, section) in left.sections.iter().enumerate() {
             for (symbol_idx, symbol) in section.symbols.iter().enumerate() {
+                let symbol_ref = SymbolRef { section_idx, symbol_idx };
+                if left_used.contains(&symbol_ref) {
+                    continue;
+                }
                 let symbol_match = SymbolMatch {
-                    left: Some(SymbolRef { section_idx, symbol_idx }),
-                    right: find_symbol(right, symbol, section, Some(&right_used), overrides),
-                    prev: find_symbol(prev, symbol, section, None, &Default::default()),
+                    left: Some(symbol_ref),
+                    right: find_symbol(right, symbol, section, Some(&right_used)),
+                    prev: find_symbol(prev, symbol, section, None),
                     section_kind: section.kind,
                 };
                 matches.push(symbol_match);
@@ -627,8 +751,12 @@ fn matching_symbols(
             }
         }
         for (symbol_idx, symbol) in left.common.iter().enumerate() {
+            let symbol_ref = SymbolRef { section_idx: left.sections.len(), symbol_idx };
+            if left_used.contains(&symbol_ref) {
+                continue;
+            }
             let symbol_match = SymbolMatch {
-                left: Some(SymbolRef { section_idx: left.sections.len(), symbol_idx }),
+                left: Some(symbol_ref),
                 right: find_common_symbol(right, symbol),
                 prev: find_common_symbol(prev, symbol),
                 section_kind: ObjSectionKind::Bss,
@@ -649,7 +777,7 @@ fn matching_symbols(
                 matches.push(SymbolMatch {
                     left: None,
                     right: Some(symbol_ref),
-                    prev: find_symbol(prev, symbol, section, None, &Default::default()),
+                    prev: find_symbol(prev, symbol, section, None),
                     section_kind: section.kind,
                 });
             }
@@ -689,23 +817,8 @@ fn find_symbol(
     in_symbol: &ObjSymbol,
     in_section: &ObjSection,
     used: Option<&HashSet<SymbolRef>>,
-    overrides: &SymbolOverrides,
 ) -> Option<SymbolRef> {
     let obj = obj?;
-    // Check for a symbol override
-    if let Some(symbol_override) = overrides.get(&in_symbol.name) {
-        symbol_override.left.as_ref()?;
-        let right_name = symbol_override.right.as_ref()?;
-        if let Some((section_idx, section)) =
-            obj.sections.iter().enumerate().find(|(_, s)| s.name == in_section.name)
-        {
-            if let Some((symbol_idx, _)) = unmatched_symbols(section, section_idx, used)
-                .find(|(_, symbol)| &symbol.name == right_name)
-            {
-                return Some(SymbolRef { section_idx, symbol_idx });
-            }
-        }
-    }
     // Try to find an exact name match
     for (section_idx, section) in obj.sections.iter().enumerate() {
         if section.kind != in_section.kind {

--- a/objdiff-core/src/obj/mod.rs
+++ b/objdiff-core/src/obj/mod.rs
@@ -112,6 +112,15 @@ pub struct ObjIns {
     pub orig: Option<String>,
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
+pub enum ObjSymbolKind {
+    #[default]
+    Unknown,
+    Function,
+    Object,
+    Section,
+}
+
 #[derive(Debug, Clone)]
 pub struct ObjSymbol {
     pub name: String,
@@ -120,6 +129,7 @@ pub struct ObjSymbol {
     pub section_address: u64,
     pub size: u64,
     pub size_known: bool,
+    pub kind: ObjSymbolKind,
     pub flags: ObjSymbolFlagSet,
     pub addend: i64,
     /// Original virtual address (from .note.split section)

--- a/objdiff-gui/src/app.rs
+++ b/objdiff-gui/src/app.rs
@@ -281,6 +281,7 @@ impl App {
                 if state.config.selected_obj.is_some() {
                     state.queue_build = true;
                 }
+                state.config.diff_obj_config.symbol_overrides.clear();
                 app.view_state.config_state.queue_check_update = state.config.auto_update_check;
                 app.state = Arc::new(RwLock::new(state));
             }

--- a/objdiff-gui/src/app.rs
+++ b/objdiff-gui/src/app.rs
@@ -15,7 +15,8 @@ use globset::{Glob, GlobSet};
 use notify::{RecursiveMode, Watcher};
 use objdiff_core::{
     config::{
-        build_globset, ProjectConfigInfo, ProjectObject, ScratchConfig, DEFAULT_WATCH_PATTERNS,
+        build_globset, save_project_config, ProjectConfig, ProjectConfigInfo, ProjectObject,
+        ScratchConfig, SymbolMappings, DEFAULT_WATCH_PATTERNS,
     },
     diff::DiffObjConfig,
 };
@@ -42,7 +43,7 @@ use crate::{
         graphics::{graphics_window, GraphicsConfig, GraphicsViewState},
         jobs::{jobs_menu_ui, jobs_window},
         rlwinm::{rlwinm_decode_window, RlwinmDecodeViewState},
-        symbol_diff::{symbol_diff_ui, DiffViewState, View},
+        symbol_diff::{symbol_diff_ui, DiffViewAction, DiffViewNavigation, DiffViewState, View},
     },
 };
 
@@ -89,7 +90,7 @@ impl Default for ViewState {
 }
 
 /// The configuration for a single object file.
-#[derive(Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ObjectConfig {
     pub name: String,
     pub target_path: Option<PathBuf>,
@@ -98,6 +99,23 @@ pub struct ObjectConfig {
     pub complete: Option<bool>,
     pub scratch: Option<ScratchConfig>,
     pub source_path: Option<String>,
+    #[serde(default)]
+    pub symbol_mappings: SymbolMappings,
+}
+
+impl From<&ProjectObject> for ObjectConfig {
+    fn from(object: &ProjectObject) -> Self {
+        Self {
+            name: object.name().to_string(),
+            target_path: object.target_path.clone(),
+            base_path: object.base_path.clone(),
+            reverse_fn_order: object.reverse_fn_order(),
+            complete: object.complete(),
+            scratch: object.scratch.clone(),
+            source_path: object.source_path().cloned(),
+            symbol_mappings: object.symbol_mappings.clone().unwrap_or_default(),
+        }
+    }
 }
 
 #[inline]
@@ -117,8 +135,14 @@ pub struct AppState {
     pub obj_change: bool,
     pub queue_build: bool,
     pub queue_reload: bool,
+    pub current_project_config: Option<ProjectConfig>,
     pub project_config_info: Option<ProjectConfigInfo>,
     pub last_mod_check: Instant,
+    /// The right object symbol name that we're selecting a left symbol for
+    pub selecting_left: Option<String>,
+    /// The left object symbol name that we're selecting a right symbol for
+    pub selecting_right: Option<String>,
+    pub config_error: Option<String>,
 }
 
 impl Default for AppState {
@@ -132,8 +156,12 @@ impl Default for AppState {
             obj_change: false,
             queue_build: false,
             queue_reload: false,
+            current_project_config: None,
             project_config_info: None,
             last_mod_check: Instant::now(),
+            selecting_left: None,
+            selecting_right: None,
+            config_error: None,
         }
     }
 }
@@ -214,7 +242,10 @@ impl AppState {
         self.config_change = true;
         self.obj_change = true;
         self.queue_build = false;
+        self.current_project_config = None;
         self.project_config_info = None;
+        self.selecting_left = None;
+        self.selecting_right = None;
     }
 
     pub fn set_target_obj_dir(&mut self, path: PathBuf) {
@@ -222,6 +253,8 @@ impl AppState {
         self.config.selected_obj = None;
         self.obj_change = true;
         self.queue_build = false;
+        self.selecting_left = None;
+        self.selecting_right = None;
     }
 
     pub fn set_base_obj_dir(&mut self, path: PathBuf) {
@@ -229,12 +262,122 @@ impl AppState {
         self.config.selected_obj = None;
         self.obj_change = true;
         self.queue_build = false;
+        self.selecting_left = None;
+        self.selecting_right = None;
     }
 
-    pub fn set_selected_obj(&mut self, object: ObjectConfig) {
-        self.config.selected_obj = Some(object);
+    pub fn set_selected_obj(&mut self, config: ObjectConfig) {
+        if self.config.selected_obj.as_ref().is_some_and(|existing| existing == &config) {
+            // Don't reload the object if there were no changes
+            return;
+        }
+        self.config.selected_obj = Some(config);
         self.obj_change = true;
         self.queue_build = false;
+        self.selecting_left = None;
+        self.selecting_right = None;
+    }
+
+    pub fn clear_selected_obj(&mut self) {
+        self.config.selected_obj = None;
+        self.obj_change = true;
+        self.queue_build = false;
+        self.selecting_left = None;
+        self.selecting_right = None;
+    }
+
+    pub fn set_selecting_left(&mut self, right: &str) {
+        let Some(object) = self.config.selected_obj.as_mut() else {
+            return;
+        };
+        object.symbol_mappings.remove_by_right(right);
+        self.selecting_left = Some(right.to_string());
+        self.queue_reload = true;
+        self.save_config();
+    }
+
+    pub fn set_selecting_right(&mut self, left: &str) {
+        let Some(object) = self.config.selected_obj.as_mut() else {
+            return;
+        };
+        object.symbol_mappings.remove_by_left(left);
+        self.selecting_right = Some(left.to_string());
+        self.queue_reload = true;
+        self.save_config();
+    }
+
+    pub fn set_symbol_mapping(&mut self, left: String, right: String) {
+        let Some(object) = self.config.selected_obj.as_mut() else {
+            log::warn!("No selected object");
+            return;
+        };
+        self.selecting_left = None;
+        self.selecting_right = None;
+        if left == right {
+            object.symbol_mappings.remove_by_left(&left);
+            object.symbol_mappings.remove_by_right(&right);
+        } else {
+            object.symbol_mappings.insert(left.clone(), right.clone());
+        }
+        self.queue_reload = true;
+        self.save_config();
+    }
+
+    pub fn clear_selection(&mut self) {
+        self.selecting_left = None;
+        self.selecting_right = None;
+        self.queue_reload = true;
+    }
+
+    pub fn clear_mappings(&mut self) {
+        self.selecting_left = None;
+        self.selecting_right = None;
+        if let Some(object) = self.config.selected_obj.as_mut() {
+            object.symbol_mappings.clear();
+        }
+        self.queue_reload = true;
+        self.save_config();
+    }
+
+    pub fn is_selecting_symbol(&self) -> bool {
+        self.selecting_left.is_some() || self.selecting_right.is_some()
+    }
+
+    pub fn save_config(&mut self) {
+        let (Some(config), Some(info)) =
+            (self.current_project_config.as_mut(), self.project_config_info.as_mut())
+        else {
+            return;
+        };
+        // Update the project config with the current state
+        if let Some(object) = self.config.selected_obj.as_ref() {
+            if let Some(existing) = config.units.as_mut().and_then(|v| {
+                v.iter_mut().find(|u| u.name.as_ref().is_some_and(|n| n == &object.name))
+            }) {
+                existing.symbol_mappings = if object.symbol_mappings.is_empty() {
+                    None
+                } else {
+                    Some(object.symbol_mappings.clone())
+                };
+            }
+            if let Some(existing) =
+                self.objects.iter_mut().find(|u| u.name.as_ref().is_some_and(|n| n == &object.name))
+            {
+                existing.symbol_mappings = if object.symbol_mappings.is_empty() {
+                    None
+                } else {
+                    Some(object.symbol_mappings.clone())
+                };
+            }
+        }
+        // Save the updated project config
+        match save_project_config(config, info) {
+            Ok(new_info) => *info = new_info,
+            Err(e) => {
+                log::error!("Failed to save project config: {e}");
+                self.config_error = Some(format!("Failed to save project config: {e}"));
+            }
+        }
     }
 }
 
@@ -281,7 +424,6 @@ impl App {
                 if state.config.selected_obj.is_some() {
                     state.queue_build = true;
                 }
-                state.config.diff_obj_config.symbol_overrides.clear();
                 app.view_state.config_state.queue_check_update = state.config.auto_update_check;
                 app.state = Arc::new(RwLock::new(state));
             }
@@ -374,31 +516,41 @@ impl App {
         debug_assert!(jobs.results.is_empty());
     }
 
-    fn post_update(&mut self, ctx: &egui::Context) {
+    fn post_update(&mut self, ctx: &egui::Context, action: Option<DiffViewAction>) {
         self.appearance.post_update(ctx);
 
         let ViewState { jobs, diff_state, config_state, graphics_state, .. } = &mut self.view_state;
         config_state.post_update(ctx, jobs, &self.state);
-        diff_state.post_update(ctx, jobs, &self.state);
+        diff_state.post_update(action, ctx, jobs, &self.state);
 
         let Ok(mut state) = self.state.write() else {
             return;
         };
         let state = &mut *state;
 
-        if let Some(info) = &state.project_config_info {
-            if file_modified(&info.path, info.timestamp) {
-                state.config_change = true;
+        let mut mod_check = false;
+        if state.last_mod_check.elapsed().as_millis() >= 500 {
+            state.last_mod_check = Instant::now();
+            mod_check = true;
+        }
+
+        if mod_check {
+            if let Some(info) = &state.project_config_info {
+                if let Some(last_ts) = info.timestamp {
+                    if file_modified(&info.path, last_ts) {
+                        state.config_change = true;
+                    }
+                }
             }
         }
 
         if state.config_change {
             state.config_change = false;
             match load_project_config(state) {
-                Ok(()) => config_state.load_error = None,
+                Ok(()) => state.config_error = None,
                 Err(e) => {
                     log::error!("Failed to load project config: {e}");
-                    config_state.load_error = Some(format!("{e}"));
+                    state.config_error = Some(format!("{e}"));
                 }
             }
         }
@@ -433,8 +585,7 @@ impl App {
         }
 
         if let Some(result) = &diff_state.build {
-            if state.last_mod_check.elapsed().as_millis() >= 500 {
-                state.last_mod_check = Instant::now();
+            if mod_check {
                 if let Some((obj, _)) = &result.first_obj {
                     if let (Some(path), Some(timestamp)) = (&obj.path, obj.timestamp) {
                         if file_modified(path, timestamp) {
@@ -458,11 +609,11 @@ impl App {
             && state.config.selected_obj.is_some()
             && !jobs.is_running(Job::ObjDiff)
         {
-            jobs.push(start_build(ctx, ObjDiffConfig::from_config(&state.config)));
+            jobs.push(start_build(ctx, ObjDiffConfig::from_state(state)));
             state.queue_build = false;
             state.queue_reload = false;
         } else if state.queue_reload && !jobs.is_running(Job::ObjDiff) {
-            let mut diff_config = ObjDiffConfig::from_config(&state.config);
+            let mut diff_config = ObjDiffConfig::from_state(state);
             // Don't build, just reload the current files
             diff_config.build_base = false;
             diff_config.build_target = false;
@@ -637,6 +788,11 @@ impl eframe::App for App {
                     {
                         state.queue_reload = true;
                     }
+                    if ui.button("Clear custom symbol mappings").clicked() {
+                        state.clear_mappings();
+                        diff_state.post_build_nav = Some(DiffViewNavigation::symbol_diff());
+                        state.queue_reload = true;
+                    }
                 });
                 ui.separator();
                 if jobs_menu_ui(ui, jobs, appearance) {
@@ -653,17 +809,18 @@ impl eframe::App for App {
             });
         }
 
+        let mut action = None;
         egui::CentralPanel::default().show(ctx, |ui| {
             let build_success = matches!(&diff_state.build, Some(b) if b.first_status.success && b.second_status.success);
-            if diff_state.current_view == View::FunctionDiff && build_success {
-                function_diff_ui(ui, diff_state, appearance);
+            action = if diff_state.current_view == View::FunctionDiff && build_success {
+                function_diff_ui(ui, diff_state, appearance)
             } else if diff_state.current_view == View::DataDiff && build_success {
-                data_diff_ui(ui, diff_state, appearance);
+                data_diff_ui(ui, diff_state, appearance)
             } else if diff_state.current_view == View::ExtabDiff && build_success {
-                extab_diff_ui(ui, diff_state, appearance);
+                extab_diff_ui(ui, diff_state, appearance)
             } else {
-                symbol_diff_ui(ui, diff_state, appearance);
-            }
+                symbol_diff_ui(ui, diff_state, appearance)
+            };
         });
 
         project_window(ctx, state, show_project_config, config_state, appearance);
@@ -675,10 +832,10 @@ impl eframe::App for App {
         graphics_window(ctx, show_graphics, frame_history, graphics_state, appearance);
         jobs_window(ctx, show_jobs, jobs, appearance);
 
-        self.post_update(ctx);
+        self.post_update(ctx, action);
     }
 
-    /// Called by the frame work to save state before shutdown.
+    /// Called by the framework to save state before shutdown.
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
         if let Ok(state) = self.state.read() {
             eframe::set_value(storage, CONFIG_KEY, &state.config);

--- a/objdiff-gui/src/app_config.rs
+++ b/objdiff-gui/src/app_config.rs
@@ -2,6 +2,10 @@ use std::path::PathBuf;
 
 use eframe::Storage;
 use globset::Glob;
+use objdiff_core::{
+    config::ScratchConfig,
+    diff::{ArmArchVersion, ArmR9Usage, DiffObjConfig, MipsAbi, MipsInstrCategory, X86Formatter},
+};
 
 use crate::app::{AppConfig, ObjectConfig, CONFIG_KEY};
 
@@ -11,7 +15,7 @@ pub struct AppConfigVersion {
 }
 
 impl Default for AppConfigVersion {
-    fn default() -> Self { Self { version: 1 } }
+    fn default() -> Self { Self { version: 2 } }
 }
 
 /// Deserialize the AppConfig from storage, handling upgrades from older versions.
@@ -19,7 +23,8 @@ pub fn deserialize_config(storage: &dyn Storage) -> Option<AppConfig> {
     let str = storage.get_string(CONFIG_KEY)?;
     match ron::from_str::<AppConfigVersion>(&str) {
         Ok(version) => match version.version {
-            1 => from_str::<AppConfig>(&str),
+            2 => from_str::<AppConfig>(&str),
+            1 => from_str::<AppConfigV1>(&str).map(|c| c.into_config()),
             _ => {
                 log::warn!("Unknown config version: {}", version.version);
                 None
@@ -45,6 +50,180 @@ where T: serde::de::DeserializeOwned {
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
+pub struct ScratchConfigV1 {
+    #[serde(default)]
+    pub platform: Option<String>,
+    #[serde(default)]
+    pub compiler: Option<String>,
+    #[serde(default)]
+    pub c_flags: Option<String>,
+    #[serde(default)]
+    pub ctx_path: Option<PathBuf>,
+    #[serde(default)]
+    pub build_ctx: bool,
+}
+
+impl ScratchConfigV1 {
+    fn into_config(self) -> ScratchConfig {
+        ScratchConfig {
+            platform: self.platform,
+            compiler: self.compiler,
+            c_flags: self.c_flags,
+            ctx_path: self.ctx_path,
+            build_ctx: self.build_ctx.then_some(true),
+        }
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct ObjectConfigV1 {
+    pub name: String,
+    pub target_path: Option<PathBuf>,
+    pub base_path: Option<PathBuf>,
+    pub reverse_fn_order: Option<bool>,
+    pub complete: Option<bool>,
+    pub scratch: Option<ScratchConfigV1>,
+    pub source_path: Option<String>,
+}
+
+impl ObjectConfigV1 {
+    fn into_config(self) -> ObjectConfig {
+        ObjectConfig {
+            name: self.name,
+            target_path: self.target_path,
+            base_path: self.base_path,
+            reverse_fn_order: self.reverse_fn_order,
+            complete: self.complete,
+            scratch: self.scratch.map(|scratch| scratch.into_config()),
+            source_path: self.source_path,
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+#[serde(default)]
+pub struct DiffObjConfigV1 {
+    pub relax_reloc_diffs: bool,
+    #[serde(default = "bool_true")]
+    pub space_between_args: bool,
+    pub combine_data_sections: bool,
+    // x86
+    pub x86_formatter: X86Formatter,
+    // MIPS
+    pub mips_abi: MipsAbi,
+    pub mips_instr_category: MipsInstrCategory,
+    // ARM
+    pub arm_arch_version: ArmArchVersion,
+    pub arm_unified_syntax: bool,
+    pub arm_av_registers: bool,
+    pub arm_r9_usage: ArmR9Usage,
+    pub arm_sl_usage: bool,
+    pub arm_fp_usage: bool,
+    pub arm_ip_usage: bool,
+}
+
+impl Default for DiffObjConfigV1 {
+    fn default() -> Self {
+        Self {
+            relax_reloc_diffs: false,
+            space_between_args: true,
+            combine_data_sections: false,
+            x86_formatter: Default::default(),
+            mips_abi: Default::default(),
+            mips_instr_category: Default::default(),
+            arm_arch_version: Default::default(),
+            arm_unified_syntax: true,
+            arm_av_registers: false,
+            arm_r9_usage: Default::default(),
+            arm_sl_usage: false,
+            arm_fp_usage: false,
+            arm_ip_usage: false,
+        }
+    }
+}
+
+impl DiffObjConfigV1 {
+    fn into_config(self) -> DiffObjConfig {
+        DiffObjConfig {
+            relax_reloc_diffs: self.relax_reloc_diffs,
+            space_between_args: self.space_between_args,
+            combine_data_sections: self.combine_data_sections,
+            x86_formatter: self.x86_formatter,
+            mips_abi: self.mips_abi,
+            mips_instr_category: self.mips_instr_category,
+            arm_arch_version: self.arm_arch_version,
+            arm_unified_syntax: self.arm_unified_syntax,
+            arm_av_registers: self.arm_av_registers,
+            arm_r9_usage: self.arm_r9_usage,
+            arm_sl_usage: self.arm_sl_usage,
+            arm_fp_usage: self.arm_fp_usage,
+            arm_ip_usage: self.arm_ip_usage,
+            ..Default::default()
+        }
+    }
+}
+
+#[inline]
+fn bool_true() -> bool { true }
+
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct AppConfigV1 {
+    pub version: u32,
+    #[serde(default)]
+    pub custom_make: Option<String>,
+    #[serde(default)]
+    pub custom_args: Option<Vec<String>>,
+    #[serde(default)]
+    pub selected_wsl_distro: Option<String>,
+    #[serde(default)]
+    pub project_dir: Option<PathBuf>,
+    #[serde(default)]
+    pub target_obj_dir: Option<PathBuf>,
+    #[serde(default)]
+    pub base_obj_dir: Option<PathBuf>,
+    #[serde(default)]
+    pub selected_obj: Option<ObjectConfigV1>,
+    #[serde(default = "bool_true")]
+    pub build_base: bool,
+    #[serde(default)]
+    pub build_target: bool,
+    #[serde(default = "bool_true")]
+    pub rebuild_on_changes: bool,
+    #[serde(default)]
+    pub auto_update_check: bool,
+    #[serde(default)]
+    pub watch_patterns: Vec<Glob>,
+    #[serde(default)]
+    pub recent_projects: Vec<PathBuf>,
+    #[serde(default)]
+    pub diff_obj_config: DiffObjConfigV1,
+}
+
+impl AppConfigV1 {
+    fn into_config(self) -> AppConfig {
+        log::info!("Upgrading configuration from v1");
+        AppConfig {
+            custom_make: self.custom_make,
+            custom_args: self.custom_args,
+            selected_wsl_distro: self.selected_wsl_distro,
+            project_dir: self.project_dir,
+            target_obj_dir: self.target_obj_dir,
+            base_obj_dir: self.base_obj_dir,
+            selected_obj: self.selected_obj.map(|obj| obj.into_config()),
+            build_base: self.build_base,
+            build_target: self.build_target,
+            rebuild_on_changes: self.rebuild_on_changes,
+            auto_update_check: self.auto_update_check,
+            watch_patterns: self.watch_patterns,
+            recent_projects: self.recent_projects,
+            diff_obj_config: self.diff_obj_config.into_config(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
 pub struct ObjectConfigV0 {
     pub name: String,
     pub target_path: PathBuf,
@@ -59,9 +238,7 @@ impl ObjectConfigV0 {
             target_path: Some(self.target_path),
             base_path: Some(self.base_path),
             reverse_fn_order: self.reverse_fn_order,
-            complete: None,
-            scratch: None,
-            source_path: None,
+            ..Default::default()
         }
     }
 }

--- a/objdiff-gui/src/jobs/create_scratch.rs
+++ b/objdiff-gui/src/jobs/create_scratch.rs
@@ -39,7 +39,7 @@ impl CreateScratchConfig {
         Ok(Self {
             build_config: BuildConfig::from_config(config),
             context_path: scratch_config.ctx_path.clone(),
-            build_context: scratch_config.build_ctx,
+            build_context: scratch_config.build_ctx.unwrap_or(false),
             compiler: scratch_config.compiler.clone().unwrap_or_default(),
             platform: scratch_config.platform.clone().unwrap_or_default(),
             compiler_flags: scratch_config.c_flags.clone().unwrap_or_default(),

--- a/objdiff-gui/src/jobs/mod.rs
+++ b/objdiff-gui/src/jobs/mod.rs
@@ -53,7 +53,7 @@ impl JobQueue {
     }
 
     /// Returns whether any job is running.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn any_running(&self) -> bool {
         self.jobs.iter().any(|job| {
             if let Some(handle) = &job.handle {

--- a/objdiff-gui/src/views/column_layout.rs
+++ b/objdiff-gui/src/views/column_layout.rs
@@ -1,0 +1,82 @@
+use egui::{Align, Layout, Sense, Vec2};
+use egui_extras::{Column, Size, StripBuilder, TableBuilder, TableRow};
+
+pub fn render_header(
+    ui: &mut egui::Ui,
+    available_width: f32,
+    num_columns: usize,
+    mut add_contents: impl FnMut(&mut egui::Ui, usize),
+) {
+    let column_width = available_width / num_columns as f32;
+    ui.allocate_ui_with_layout(
+        Vec2 { x: available_width, y: 100.0 },
+        Layout::left_to_right(Align::Min),
+        |ui| {
+            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
+            for i in 0..num_columns {
+                ui.allocate_ui_with_layout(
+                    Vec2 { x: column_width, y: 100.0 },
+                    Layout::top_down(Align::Min),
+                    |ui| {
+                        ui.set_width(column_width);
+                        add_contents(ui, i);
+                    },
+                );
+            }
+        },
+    );
+    ui.separator();
+}
+
+pub fn render_table(
+    ui: &mut egui::Ui,
+    available_width: f32,
+    num_columns: usize,
+    row_height: f32,
+    total_rows: usize,
+    mut add_contents: impl FnMut(&mut TableRow, usize),
+) {
+    ui.style_mut().interaction.selectable_labels = false;
+    let column_width = available_width / num_columns as f32;
+    let available_height = ui.available_height();
+    let table = TableBuilder::new(ui)
+        .striped(false)
+        .cell_layout(Layout::left_to_right(Align::Min))
+        .columns(Column::exact(column_width).clip(true), num_columns)
+        .resizable(false)
+        .auto_shrink([false, false])
+        .min_scrolled_height(available_height)
+        .sense(Sense::click());
+    table.body(|body| {
+        body.rows(row_height, total_rows, |mut row| {
+            row.set_hovered(false); // Disable hover effect
+            for i in 0..num_columns {
+                add_contents(&mut row, i);
+            }
+        });
+    });
+}
+
+pub fn render_strips(
+    ui: &mut egui::Ui,
+    available_width: f32,
+    num_columns: usize,
+    mut add_contents: impl FnMut(&mut egui::Ui, usize),
+) {
+    let column_width = available_width / num_columns as f32;
+    StripBuilder::new(ui).size(Size::remainder()).clip(true).vertical(|mut strip| {
+        strip.strip(|builder| {
+            builder.sizes(Size::exact(column_width), num_columns).clip(true).horizontal(
+                |mut strip| {
+                    for i in 0..num_columns {
+                        strip.cell(|ui| {
+                            ui.push_id(i, |ui| {
+                                add_contents(ui, i);
+                            });
+                        });
+                    }
+                },
+            );
+        });
+    });
+}

--- a/objdiff-gui/src/views/extab_diff.rs
+++ b/objdiff-gui/src/views/extab_diff.rs
@@ -1,27 +1,16 @@
-use egui::{Align, Layout, ScrollArea, Ui, Vec2};
-use egui_extras::{Size, StripBuilder};
+use egui::{RichText, ScrollArea};
 use objdiff_core::{
     arch::ppc::ExceptionInfo,
-    diff::ObjDiff,
-    obj::{ObjInfo, ObjSymbol, SymbolRef},
+    obj::{ObjInfo, ObjSymbol},
 };
 use time::format_description;
 
 use crate::views::{
     appearance::Appearance,
+    column_layout::{render_header, render_strips},
+    function_diff::FunctionDiffContext,
     symbol_diff::{match_color_for_symbol, DiffViewState, SymbolRefByName, View},
 };
-
-fn find_symbol(obj: &ObjInfo, selected_symbol: &SymbolRefByName) -> Option<SymbolRef> {
-    for (section_idx, section) in obj.sections.iter().enumerate() {
-        for (symbol_idx, symbol) in section.symbols.iter().enumerate() {
-            if symbol.name == selected_symbol.symbol_name {
-                return Some(SymbolRef { section_idx, symbol_idx });
-            }
-        }
-    }
-    None
-}
 
 fn decode_extab(extab: &ExceptionInfo) -> String {
     let mut text = String::from("");
@@ -48,14 +37,12 @@ fn find_extab_entry<'a>(obj: &'a ObjInfo, symbol: &ObjSymbol) -> Option<&'a Exce
 }
 
 fn extab_text_ui(
-    ui: &mut Ui,
-    obj: &(ObjInfo, ObjDiff),
-    symbol_ref: SymbolRef,
+    ui: &mut egui::Ui,
+    ctx: FunctionDiffContext<'_>,
+    symbol: &ObjSymbol,
     appearance: &Appearance,
 ) -> Option<()> {
-    let (_section, symbol) = obj.0.section_symbol(symbol_ref);
-
-    if let Some(extab_entry) = find_extab_entry(&obj.0, symbol) {
+    if let Some(extab_entry) = find_extab_entry(ctx.obj, symbol) {
         let text = decode_extab(extab_entry);
         ui.colored_label(appearance.replace_color, &text);
         return Some(());
@@ -65,137 +52,178 @@ fn extab_text_ui(
 }
 
 fn extab_ui(
-    ui: &mut Ui,
-    obj: Option<&(ObjInfo, ObjDiff)>,
-    selected_symbol: &SymbolRefByName,
+    ui: &mut egui::Ui,
+    ctx: FunctionDiffContext<'_>,
     appearance: &Appearance,
-    _left: bool,
+    _column: usize,
 ) {
     ScrollArea::both().auto_shrink([false, false]).show(ui, |ui| {
         ui.scope(|ui| {
             ui.style_mut().override_text_style = Some(egui::TextStyle::Monospace);
             ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
 
-            let symbol = obj.and_then(|(obj, _)| find_symbol(obj, selected_symbol));
-
-            if let (Some(object), Some(symbol_ref)) = (obj, symbol) {
-                extab_text_ui(ui, object, symbol_ref, appearance);
+            if let Some((_section, symbol)) =
+                ctx.symbol_ref.map(|symbol_ref| ctx.obj.section_symbol(symbol_ref))
+            {
+                extab_text_ui(ui, ctx, symbol, appearance);
             }
         });
     });
 }
 
 pub fn extab_diff_ui(ui: &mut egui::Ui, state: &mut DiffViewState, appearance: &Appearance) {
-    let (Some(result), Some(selected_symbol)) = (&state.build, &state.symbol_state.selected_symbol)
-    else {
+    let Some(result) = &state.build else {
         return;
     };
 
+    let mut left_ctx = FunctionDiffContext::new(
+        result.first_obj.as_ref(),
+        state.symbol_state.left_symbol.as_ref(),
+    );
+    let mut right_ctx = FunctionDiffContext::new(
+        result.second_obj.as_ref(),
+        state.symbol_state.right_symbol.as_ref(),
+    );
+
+    // If one side is missing a symbol, but the diff process found a match, use that symbol
+    let left_diff_symbol = left_ctx.and_then(|ctx| {
+        ctx.symbol_ref.and_then(|symbol_ref| ctx.diff.symbol_diff(symbol_ref).diff_symbol)
+    });
+    let right_diff_symbol = right_ctx.and_then(|ctx| {
+        ctx.symbol_ref.and_then(|symbol_ref| ctx.diff.symbol_diff(symbol_ref).diff_symbol)
+    });
+    if left_diff_symbol.is_some() && right_ctx.map_or(false, |ctx| !ctx.has_symbol()) {
+        let (right_section, right_symbol) =
+            right_ctx.unwrap().obj.section_symbol(left_diff_symbol.unwrap());
+        let symbol_ref = SymbolRefByName::new(right_symbol, right_section);
+        right_ctx = FunctionDiffContext::new(result.second_obj.as_ref(), Some(&symbol_ref));
+        state.symbol_state.right_symbol = Some(symbol_ref);
+    } else if right_diff_symbol.is_some() && left_ctx.map_or(false, |ctx| !ctx.has_symbol()) {
+        let (left_section, left_symbol) =
+            left_ctx.unwrap().obj.section_symbol(right_diff_symbol.unwrap());
+        let symbol_ref = SymbolRefByName::new(left_symbol, left_section);
+        left_ctx = FunctionDiffContext::new(result.first_obj.as_ref(), Some(&symbol_ref));
+        state.symbol_state.left_symbol = Some(symbol_ref);
+    }
+
+    // If both sides are missing a symbol, switch to symbol diff view
+    if !right_ctx.map_or(false, |ctx| ctx.has_symbol())
+        && !left_ctx.map_or(false, |ctx| ctx.has_symbol())
+    {
+        state.current_view = View::SymbolDiff;
+        state.symbol_state.left_symbol = None;
+        state.symbol_state.right_symbol = None;
+        return;
+    }
+
     // Header
     let available_width = ui.available_width();
-    let column_width = available_width / 2.0;
-    ui.allocate_ui_with_layout(
-        Vec2 { x: available_width, y: 100.0 },
-        Layout::left_to_right(Align::Min),
-        |ui| {
-            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
-
+    render_header(ui, available_width, 2, |ui, column| {
+        if column == 0 {
             // Left column
-            ui.allocate_ui_with_layout(
-                Vec2 { x: column_width, y: 100.0 },
-                Layout::top_down(Align::Min),
-                |ui| {
-                    ui.set_width(column_width);
+            ui.horizontal(|ui| {
+                if ui.button("⏴ Back").clicked() {
+                    state.current_view = View::SymbolDiff;
+                }
+                ui.separator();
+                if ui
+                    .add_enabled(
+                        !state.scratch_running
+                            && state.scratch_available
+                            && left_ctx.map_or(false, |ctx| ctx.has_symbol()),
+                        egui::Button::new("📲 decomp.me"),
+                    )
+                    .on_hover_text_at_pointer("Create a new scratch on decomp.me (beta)")
+                    .on_disabled_hover_text("Scratch configuration missing")
+                    .clicked()
+                {
+                    state.queue_scratch = true;
+                }
+            });
 
-                    ui.horizontal(|ui| {
-                        if ui.button("⏴ Back").clicked() {
-                            state.current_view = View::SymbolDiff;
-                        }
-                    });
-
-                    let name = selected_symbol
-                        .demangled_symbol_name
-                        .as_deref()
-                        .unwrap_or(&selected_symbol.symbol_name);
-                    ui.scope(|ui| {
-                        ui.style_mut().override_text_style = Some(egui::TextStyle::Monospace);
-                        ui.colored_label(appearance.highlight_color, name);
-                        ui.label("Diff target:");
-                    });
-                },
-            );
-
+            if let Some((_section, symbol)) = left_ctx
+                .and_then(|ctx| ctx.symbol_ref.map(|symbol_ref| ctx.obj.section_symbol(symbol_ref)))
+            {
+                let name = symbol.demangled_name.as_deref().unwrap_or(&symbol.name);
+                ui.label(
+                    RichText::new(name)
+                        .font(appearance.code_font.clone())
+                        .color(appearance.highlight_color),
+                );
+            } else {
+                ui.label(
+                    RichText::new("Missing")
+                        .font(appearance.code_font.clone())
+                        .color(appearance.replace_color),
+                );
+            }
+        } else if column == 1 {
             // Right column
-            ui.allocate_ui_with_layout(
-                Vec2 { x: column_width, y: 100.0 },
-                Layout::top_down(Align::Min),
-                |ui| {
-                    ui.set_width(column_width);
+            ui.horizontal(|ui| {
+                if ui.add_enabled(!state.build_running, egui::Button::new("Build")).clicked() {
+                    state.queue_build = true;
+                }
+                ui.scope(|ui| {
+                    ui.style_mut().override_text_style = Some(egui::TextStyle::Monospace);
+                    if state.build_running {
+                        ui.colored_label(appearance.replace_color, "Building…");
+                    } else {
+                        ui.label("Last built:");
+                        let format = format_description::parse("[hour]:[minute]:[second]").unwrap();
+                        ui.label(
+                            result.time.to_offset(appearance.utc_offset).format(&format).unwrap(),
+                        );
+                    }
+                });
+                ui.separator();
+                if ui
+                    .add_enabled(state.source_path_available, egui::Button::new("🖹 Source file"))
+                    .on_hover_text_at_pointer("Open the source file in the default editor")
+                    .on_disabled_hover_text("Source file metadata missing")
+                    .clicked()
+                {
+                    state.queue_open_source_path = true;
+                }
+            });
 
-                    ui.horizontal(|ui| {
-                        if ui
-                            .add_enabled(!state.build_running, egui::Button::new("Build"))
-                            .clicked()
-                        {
-                            state.queue_build = true;
-                        }
-                        ui.scope(|ui| {
-                            ui.style_mut().override_text_style = Some(egui::TextStyle::Monospace);
-                            if state.build_running {
-                                ui.colored_label(appearance.replace_color, "Building…");
-                            } else {
-                                ui.label("Last built:");
-                                let format =
-                                    format_description::parse("[hour]:[minute]:[second]").unwrap();
-                                ui.label(
-                                    result
-                                        .time
-                                        .to_offset(appearance.utc_offset)
-                                        .format(&format)
-                                        .unwrap(),
-                                );
-                            }
-                        });
-                    });
-
-                    ui.scope(|ui| {
-                        ui.style_mut().override_text_style = Some(egui::TextStyle::Monospace);
-                        if let Some(match_percent) = result
-                            .second_obj
-                            .as_ref()
-                            .and_then(|(obj, diff)| {
-                                find_symbol(obj, selected_symbol).map(|sref| {
-                                    &diff.sections[sref.section_idx].symbols[sref.symbol_idx]
-                                })
-                            })
-                            .and_then(|symbol| symbol.match_percent)
-                        {
-                            ui.colored_label(
-                                match_color_for_symbol(match_percent, appearance),
-                                format!("{:.0}%", match_percent.floor()),
-                            );
-                        } else {
-                            ui.colored_label(appearance.replace_color, "Missing");
-                        }
-                        ui.label("Diff base:");
-                    });
-                },
-            );
-        },
-    );
-    ui.separator();
+            if let Some(((_section, symbol), symbol_diff)) = right_ctx.and_then(|ctx| {
+                ctx.symbol_ref.map(|symbol_ref| {
+                    (ctx.obj.section_symbol(symbol_ref), ctx.diff.symbol_diff(symbol_ref))
+                })
+            }) {
+                let name = symbol.demangled_name.as_deref().unwrap_or(&symbol.name);
+                ui.label(
+                    RichText::new(name)
+                        .font(appearance.code_font.clone())
+                        .color(appearance.highlight_color),
+                );
+                if let Some(match_percent) = symbol_diff.match_percent {
+                    ui.label(
+                        RichText::new(format!("{:.0}%", match_percent.floor()))
+                            .font(appearance.code_font.clone())
+                            .color(match_color_for_symbol(match_percent, appearance)),
+                    );
+                }
+            } else {
+                ui.label(
+                    RichText::new("Missing")
+                        .font(appearance.code_font.clone())
+                        .color(appearance.replace_color),
+                );
+            }
+        }
+    });
 
     // Table
-    StripBuilder::new(ui).size(Size::remainder()).vertical(|mut strip| {
-        strip.strip(|builder| {
-            builder.sizes(Size::remainder(), 2).horizontal(|mut strip| {
-                strip.cell(|ui| {
-                    extab_ui(ui, result.first_obj.as_ref(), selected_symbol, appearance, true);
-                });
-                strip.cell(|ui| {
-                    extab_ui(ui, result.second_obj.as_ref(), selected_symbol, appearance, false);
-                });
-            });
-        });
+    render_strips(ui, available_width, 2, |ui, column| {
+        if column == 0 {
+            if let Some(ctx) = left_ctx {
+                extab_ui(ui, ctx, appearance, column);
+            }
+        } else if column == 1 {
+            if let Some(ctx) = right_ctx {
+                extab_ui(ui, ctx, appearance, column);
+            }
+        }
     });
 }

--- a/objdiff-gui/src/views/mod.rs
+++ b/objdiff-gui/src/views/mod.rs
@@ -1,6 +1,7 @@
 use egui::{text::LayoutJob, Color32, FontId, TextFormat};
 
 pub(crate) mod appearance;
+pub(crate) mod column_layout;
 pub(crate) mod config;
 pub(crate) mod data_diff;
 pub(crate) mod debug;


### PR DESCRIPTION
This allows users to "map" (or "link") symbols with different names so that they can be compared without having to update either the target or base objects. Symbol mappings are persisted in `objdiff.json`, so generators will need to ensure that they're preserved when updating. (Example: https://github.com/encounter/dtk-template/commit/d1334bb79e71af1a7b3b090bffda4adc483f722c)

https://github.com/user-attachments/assets/fe3ae445-d738-47ac-9a66-4dbe594027ce

Resolves #117 