### PR TITLE
Fix data tooltip panic

### DIFF
--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -34,6 +34,9 @@ pub enum DataType {
 
 impl DataType {
     pub fn display_bytes<Endian: ByteOrder>(&self, bytes: &[u8]) -> Option<String> {
+        // TODO: Attempt to interpret large symbols as arrays of a smaller type,
+        // fallback to intrepreting it as bytes.
+        // https://github.com/encounter/objdiff/issues/124
         if self.required_len().is_some_and(|l| bytes.len() != l) {
             return None;
         }

--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -38,6 +38,7 @@ impl DataType {
         // fallback to intrepreting it as bytes.
         // https://github.com/encounter/objdiff/issues/124
         if self.required_len().is_some_and(|l| bytes.len() != l) {
+            log::warn!("Failed to display a symbol value for a symbol whose size doesn't match the instruction referencing it.");
             return None;
         }
 

--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -34,12 +34,9 @@ pub enum DataType {
 
 impl DataType {
     pub fn display_bytes<Endian: ByteOrder>(&self, bytes: &[u8]) -> Option<String> {
-        let Some(required_len) = self.required_len() else {
+        if self.required_len().is_some_and(|l| bytes.len() != l) {
             return None;
-        };
-        // TODO: For symbols larger than their data type, we should probably support
-        // using the relocation's relative offset to read the bytes.
-        let bytes = bytes.get(0..required_len)?;
+        }
 
         match self {
             DataType::Int8 => {

--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -34,9 +34,12 @@ pub enum DataType {
 
 impl DataType {
     pub fn display_bytes<Endian: ByteOrder>(&self, bytes: &[u8]) -> Option<String> {
-        if self.required_len().is_some_and(|l| bytes.len() < l) {
+        let Some(required_len) = self.required_len() else {
             return None;
-        }
+        };
+        // TODO: For symbols larger than their data type, we should probably support
+        // using the relocation's relative offset to read the bytes.
+        let bytes = bytes.get(0..required_len)?;
 
         match self {
             DataType::Int8 => {


### PR DESCRIPTION
Prevents panicing when attempting to display the data tooltip for a symbol that is too large by just using as many bytes as needed from the begging of the symbol.

This is a quick fix for the data tooltip panic that matches my original intention behind the code.

As discussed in discord we have a few different options when the symbol's size is larger than the data type associated with the instruction used.

A) Return None and have no tooltip
B) Interpret the value starting from the beginning of the symbol
C) Interpret the value starting from the relative offset of the symbol
D) Show the value of the entire symbol interpreted as a larger data type

This implements B, but I think C would be better. That needs some additional work though to make happen. IMO A and D are just bad.