### PR TITLE
objdiff-gui: Implement keyboard shortcuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ android.keystore
 *.frag
 *.vert
 *.metal
-.vscode/launch.json
+.vscode/

--- a/objdiff-gui/Cargo.toml
+++ b/objdiff-gui/Cargo.toml
@@ -95,7 +95,7 @@ exec = "0.3"
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/objdiff-gui/src/app.rs
+++ b/objdiff-gui/src/app.rs
@@ -831,6 +831,8 @@ impl eframe::App for App {
             } else {
                 symbol_diff_ui(ui, diff_state, appearance)
             };
+            // Clear the autoscroll flag so it doesn't scroll continuously.
+            diff_state.symbol_state.autoscroll_to_highlighted_symbols = false;
         });
 
         project_window(ctx, state, show_project_config, config_state, appearance);

--- a/objdiff-gui/src/app.rs
+++ b/objdiff-gui/src/app.rs
@@ -831,8 +831,6 @@ impl eframe::App for App {
             } else {
                 symbol_diff_ui(ui, diff_state, appearance)
             };
-            // Clear the autoscroll flag so it doesn't scroll continuously.
-            diff_state.symbol_state.autoscroll_to_highlighted_symbols = false;
         });
 
         project_window(ctx, state, show_project_config, config_state, appearance);

--- a/objdiff-gui/src/hotkeys.rs
+++ b/objdiff-gui/src/hotkeys.rs
@@ -1,4 +1,6 @@
-use egui::{style::ScrollAnimation, vec2, Context, Key, Modifiers, PointerButton};
+use egui::{
+    style::ScrollAnimation, vec2, Context, Key, KeyboardShortcut, Modifiers, PointerButton,
+};
 
 fn any_widget_focused(ctx: &Context) -> bool { ctx.memory(|mem| mem.focused().is_some()) }
 
@@ -73,4 +75,16 @@ pub fn consume_down_key(ctx: &Context) -> bool {
     ctx.input_mut(|i| {
         i.consume_key(Modifiers::NONE, Key::ArrowDown) || i.consume_key(Modifiers::NONE, Key::S)
     })
+}
+
+const OBJECT_FILTER_SHORTCUT: KeyboardShortcut = KeyboardShortcut::new(Modifiers::CTRL, Key::F);
+
+pub fn consume_object_filter_shortcut(ctx: &Context) -> bool {
+    ctx.input_mut(|i| i.consume_shortcut(&OBJECT_FILTER_SHORTCUT))
+}
+
+const SYMBOL_FILTER_SHORTCUT: KeyboardShortcut = KeyboardShortcut::new(Modifiers::CTRL, Key::S);
+
+pub fn consume_symbol_filter_shortcut(ctx: &Context) -> bool {
+    ctx.input_mut(|i| i.consume_shortcut(&SYMBOL_FILTER_SHORTCUT))
 }

--- a/objdiff-gui/src/hotkeys.rs
+++ b/objdiff-gui/src/hotkeys.rs
@@ -1,4 +1,4 @@
-use egui::{Context, Key, PointerButton};
+use egui::{style::ScrollAnimation, vec2, Context, Key, PointerButton};
 
 pub fn enter_pressed(ctx: &Context) -> bool {
     ctx.input_mut(|i| i.key_pressed(Key::Enter) || i.pointer.button_pressed(PointerButton::Extra2))
@@ -8,4 +8,37 @@ pub fn back_pressed(ctx: &Context) -> bool {
     ctx.input_mut(|i| {
         i.key_pressed(Key::Backspace) || i.pointer.button_pressed(PointerButton::Extra1)
     })
+}
+
+pub fn up_pressed(ctx: &Context) -> bool {
+    ctx.input_mut(|i| i.key_pressed(Key::ArrowUp) || i.key_pressed(Key::W))
+}
+
+pub fn down_pressed(ctx: &Context) -> bool {
+    ctx.input_mut(|i| i.key_pressed(Key::ArrowDown) || i.key_pressed(Key::S))
+}
+
+pub fn page_up_pressed(ctx: &Context) -> bool { ctx.input_mut(|i| i.key_pressed(Key::PageUp)) }
+
+pub fn page_down_pressed(ctx: &Context) -> bool { ctx.input_mut(|i| i.key_pressed(Key::PageDown)) }
+
+pub fn home_pressed(ctx: &Context) -> bool { ctx.input_mut(|i| i.key_pressed(Key::Home)) }
+
+pub fn end_pressed(ctx: &Context) -> bool { ctx.input_mut(|i| i.key_pressed(Key::End)) }
+
+pub fn check_scroll_hotkeys(ui: &mut egui::Ui) {
+    let ui_height = ui.available_rect_before_wrap().height();
+    if up_pressed(ui.ctx()) {
+        ui.scroll_with_delta_animation(vec2(0.0, ui_height / 10.0), ScrollAnimation::none());
+    } else if down_pressed(ui.ctx()) {
+        ui.scroll_with_delta_animation(vec2(0.0, -ui_height / 10.0), ScrollAnimation::none());
+    } else if page_up_pressed(ui.ctx()) {
+        ui.scroll_with_delta_animation(vec2(0.0, ui_height), ScrollAnimation::none());
+    } else if page_down_pressed(ui.ctx()) {
+        ui.scroll_with_delta_animation(vec2(0.0, -ui_height), ScrollAnimation::none());
+    } else if home_pressed(ui.ctx()) {
+        ui.scroll_with_delta_animation(vec2(0.0, f32::INFINITY), ScrollAnimation::none());
+    } else if end_pressed(ui.ctx()) {
+        ui.scroll_with_delta_animation(vec2(0.0, -f32::INFINITY), ScrollAnimation::none());
+    }
 }

--- a/objdiff-gui/src/hotkeys.rs
+++ b/objdiff-gui/src/hotkeys.rs
@@ -92,3 +92,15 @@ const SYMBOL_FILTER_SHORTCUT: KeyboardShortcut = KeyboardShortcut::new(Modifiers
 pub fn consume_symbol_filter_shortcut(ctx: &Context) -> bool {
     ctx.input_mut(|i| i.consume_shortcut(&SYMBOL_FILTER_SHORTCUT))
 }
+
+const CHANGE_TARGET_SHORTCUT: KeyboardShortcut = KeyboardShortcut::new(Modifiers::CTRL, Key::T);
+
+pub fn consume_change_target_shortcut(ctx: &Context) -> bool {
+    ctx.input_mut(|i| i.consume_shortcut(&CHANGE_TARGET_SHORTCUT))
+}
+
+const CHANGE_BASE_SHORTCUT: KeyboardShortcut = KeyboardShortcut::new(Modifiers::CTRL, Key::B);
+
+pub fn consume_change_base_shortcut(ctx: &Context) -> bool {
+    ctx.input_mut(|i| i.consume_shortcut(&CHANGE_BASE_SHORTCUT))
+}

--- a/objdiff-gui/src/hotkeys.rs
+++ b/objdiff-gui/src/hotkeys.rs
@@ -8,7 +8,11 @@ pub fn enter_pressed(ctx: &Context) -> bool {
     if any_widget_focused(ctx) {
         return false;
     }
-    ctx.input_mut(|i| i.key_pressed(Key::Enter) || i.pointer.button_pressed(PointerButton::Extra2))
+    ctx.input_mut(|i| {
+        i.key_pressed(Key::Enter)
+            || i.key_pressed(Key::Space)
+            || i.pointer.button_pressed(PointerButton::Extra2)
+    })
 }
 
 pub fn back_pressed(ctx: &Context) -> bool {

--- a/objdiff-gui/src/hotkeys.rs
+++ b/objdiff-gui/src/hotkeys.rs
@@ -1,0 +1,11 @@
+use egui::{Context, Key, PointerButton};
+
+pub fn enter_pressed(ctx: &Context) -> bool {
+    ctx.input_mut(|i| i.key_pressed(Key::Enter) || i.pointer.button_pressed(PointerButton::Extra2))
+}
+
+pub fn back_pressed(ctx: &Context) -> bool {
+    ctx.input_mut(|i| {
+        i.key_pressed(Key::Backspace) || i.pointer.button_pressed(PointerButton::Extra1)
+    })
+}

--- a/objdiff-gui/src/hotkeys.rs
+++ b/objdiff-gui/src/hotkeys.rs
@@ -1,4 +1,4 @@
-use egui::{style::ScrollAnimation, vec2, Context, Key, PointerButton};
+use egui::{style::ScrollAnimation, vec2, Context, Key, Modifiers, PointerButton};
 
 pub fn enter_pressed(ctx: &Context) -> bool {
     ctx.input_mut(|i| i.key_pressed(Key::Enter) || i.pointer.button_pressed(PointerButton::Extra2))
@@ -26,11 +26,11 @@ pub fn home_pressed(ctx: &Context) -> bool { ctx.input_mut(|i| i.key_pressed(Key
 
 pub fn end_pressed(ctx: &Context) -> bool { ctx.input_mut(|i| i.key_pressed(Key::End)) }
 
-pub fn check_scroll_hotkeys(ui: &mut egui::Ui) {
+pub fn check_scroll_hotkeys(ui: &mut egui::Ui, include_small_increments: bool) {
     let ui_height = ui.available_rect_before_wrap().height();
-    if up_pressed(ui.ctx()) {
+    if up_pressed(ui.ctx()) && include_small_increments {
         ui.scroll_with_delta_animation(vec2(0.0, ui_height / 10.0), ScrollAnimation::none());
-    } else if down_pressed(ui.ctx()) {
+    } else if down_pressed(ui.ctx()) && include_small_increments {
         ui.scroll_with_delta_animation(vec2(0.0, -ui_height / 10.0), ScrollAnimation::none());
     } else if page_up_pressed(ui.ctx()) {
         ui.scroll_with_delta_animation(vec2(0.0, ui_height), ScrollAnimation::none());
@@ -41,4 +41,16 @@ pub fn check_scroll_hotkeys(ui: &mut egui::Ui) {
     } else if end_pressed(ui.ctx()) {
         ui.scroll_with_delta_animation(vec2(0.0, -f32::INFINITY), ScrollAnimation::none());
     }
+}
+
+pub fn consume_up_key(ctx: &Context) -> bool {
+    ctx.input_mut(|i| {
+        i.consume_key(Modifiers::NONE, Key::ArrowUp) || i.consume_key(Modifiers::NONE, Key::W)
+    })
+}
+
+pub fn consume_down_key(ctx: &Context) -> bool {
+    ctx.input_mut(|i| {
+        i.consume_key(Modifiers::NONE, Key::ArrowDown) || i.consume_key(Modifiers::NONE, Key::S)
+    })
 }

--- a/objdiff-gui/src/hotkeys.rs
+++ b/objdiff-gui/src/hotkeys.rs
@@ -20,7 +20,9 @@ pub fn back_pressed(ctx: &Context) -> bool {
         return false;
     }
     ctx.input_mut(|i| {
-        i.key_pressed(Key::Backspace) || i.pointer.button_pressed(PointerButton::Extra1)
+        i.key_pressed(Key::Backspace)
+            || i.key_pressed(Key::Escape)
+            || i.pointer.button_pressed(PointerButton::Extra1)
     })
 }
 

--- a/objdiff-gui/src/hotkeys.rs
+++ b/objdiff-gui/src/hotkeys.rs
@@ -1,20 +1,34 @@
 use egui::{style::ScrollAnimation, vec2, Context, Key, Modifiers, PointerButton};
 
+fn any_widget_focused(ctx: &Context) -> bool { ctx.memory(|mem| mem.focused().is_some()) }
+
 pub fn enter_pressed(ctx: &Context) -> bool {
+    if any_widget_focused(ctx) {
+        return false;
+    }
     ctx.input_mut(|i| i.key_pressed(Key::Enter) || i.pointer.button_pressed(PointerButton::Extra2))
 }
 
 pub fn back_pressed(ctx: &Context) -> bool {
+    if any_widget_focused(ctx) {
+        return false;
+    }
     ctx.input_mut(|i| {
         i.key_pressed(Key::Backspace) || i.pointer.button_pressed(PointerButton::Extra1)
     })
 }
 
 pub fn up_pressed(ctx: &Context) -> bool {
+    if any_widget_focused(ctx) {
+        return false;
+    }
     ctx.input_mut(|i| i.key_pressed(Key::ArrowUp) || i.key_pressed(Key::W))
 }
 
 pub fn down_pressed(ctx: &Context) -> bool {
+    if any_widget_focused(ctx) {
+        return false;
+    }
     ctx.input_mut(|i| i.key_pressed(Key::ArrowDown) || i.key_pressed(Key::S))
 }
 
@@ -44,12 +58,18 @@ pub fn check_scroll_hotkeys(ui: &mut egui::Ui, include_small_increments: bool) {
 }
 
 pub fn consume_up_key(ctx: &Context) -> bool {
+    if any_widget_focused(ctx) {
+        return false;
+    }
     ctx.input_mut(|i| {
         i.consume_key(Modifiers::NONE, Key::ArrowUp) || i.consume_key(Modifiers::NONE, Key::W)
     })
 }
 
 pub fn consume_down_key(ctx: &Context) -> bool {
+    if any_widget_focused(ctx) {
+        return false;
+    }
     ctx.input_mut(|i| {
         i.consume_key(Modifiers::NONE, Key::ArrowDown) || i.consume_key(Modifiers::NONE, Key::S)
     })

--- a/objdiff-gui/src/main.rs
+++ b/objdiff-gui/src/main.rs
@@ -4,6 +4,7 @@ mod app;
 mod app_config;
 mod config;
 mod fonts;
+mod hotkeys;
 mod jobs;
 mod update;
 mod views;

--- a/objdiff-gui/src/views/config.rs
+++ b/objdiff-gui/src/views/config.rs
@@ -21,6 +21,7 @@ use strum::{EnumMessage, VariantArray};
 use crate::{
     app::{AppConfig, AppState, AppStateRef, ObjectConfig},
     config::ProjectObjectNode,
+    hotkeys,
     jobs::{
         check_update::{start_check_update, CheckUpdateResult},
         update::start_update,
@@ -254,7 +255,11 @@ pub fn config_ui(
         }
     } else {
         let had_search = !config_state.object_search.is_empty();
-        egui::TextEdit::singleline(&mut config_state.object_search).hint_text("Filter").ui(ui);
+        let response =
+            egui::TextEdit::singleline(&mut config_state.object_search).hint_text("Filter").ui(ui);
+        if hotkeys::consume_object_filter_shortcut(ui.ctx()) {
+            response.request_focus();
+        }
 
         let mut root_open = None;
         let mut node_open = NodeOpen::Default;

--- a/objdiff-gui/src/views/data_diff.rs
+++ b/objdiff-gui/src/views/data_diff.rs
@@ -7,11 +7,14 @@ use objdiff_core::{
 };
 use time::format_description;
 
-use crate::views::{
-    appearance::Appearance,
-    column_layout::{render_header, render_table},
-    symbol_diff::{DiffViewAction, DiffViewNavigation, DiffViewState},
-    write_text,
+use crate::{
+    hotkeys,
+    views::{
+        appearance::Appearance,
+        column_layout::{render_header, render_table},
+        symbol_diff::{DiffViewAction, DiffViewNavigation, DiffViewState},
+        write_text,
+    },
 };
 
 const BYTES_PER_ROW: usize = 16;
@@ -224,7 +227,7 @@ pub fn data_diff_ui(
     render_header(ui, available_width, 2, |ui, column| {
         if column == 0 {
             // Left column
-            if ui.button("⏴ Back").clicked() {
+            if ui.button("⏴ Back").clicked() || hotkeys::back_pressed(ui.ctx()) {
                 ret = Some(DiffViewAction::Navigate(DiffViewNavigation::symbol_diff()));
             }
 

--- a/objdiff-gui/src/views/data_diff.rs
+++ b/objdiff-gui/src/views/data_diff.rs
@@ -179,6 +179,8 @@ fn data_table_ui(
     let left_diffs = left_section.map(|(_, section)| split_diffs(&section.data_diff));
     let right_diffs = right_section.map(|(_, section)| split_diffs(&section.data_diff));
 
+    hotkeys::check_scroll_hotkeys(ui);
+
     render_table(ui, available_width, 2, config.code_font.size, total_rows, |row, column| {
         let i = row.index();
         let address = i * BYTES_PER_ROW;

--- a/objdiff-gui/src/views/data_diff.rs
+++ b/objdiff-gui/src/views/data_diff.rs
@@ -179,7 +179,7 @@ fn data_table_ui(
     let left_diffs = left_section.map(|(_, section)| split_diffs(&section.data_diff));
     let right_diffs = right_section.map(|(_, section)| split_diffs(&section.data_diff));
 
-    hotkeys::check_scroll_hotkeys(ui);
+    hotkeys::check_scroll_hotkeys(ui, true);
 
     render_table(ui, available_width, 2, config.code_font.size, total_rows, |row, column| {
         let i = row.index();

--- a/objdiff-gui/src/views/extab_diff.rs
+++ b/objdiff-gui/src/views/extab_diff.rs
@@ -235,6 +235,8 @@ pub fn extab_diff_ui(
         }
     });
 
+    hotkeys::check_scroll_hotkeys(ui);
+
     // Table
     render_strips(ui, available_width, 2, |ui, column| {
         if column == 0 {

--- a/objdiff-gui/src/views/extab_diff.rs
+++ b/objdiff-gui/src/views/extab_diff.rs
@@ -5,13 +5,16 @@ use objdiff_core::{
 };
 use time::format_description;
 
-use crate::views::{
-    appearance::Appearance,
-    column_layout::{render_header, render_strips},
-    function_diff::FunctionDiffContext,
-    symbol_diff::{
-        match_color_for_symbol, DiffViewAction, DiffViewNavigation, DiffViewState, SymbolRefByName,
-        View,
+use crate::{
+    hotkeys,
+    views::{
+        appearance::Appearance,
+        column_layout::{render_header, render_strips},
+        function_diff::FunctionDiffContext,
+        symbol_diff::{
+            match_color_for_symbol, DiffViewAction, DiffViewNavigation, DiffViewState,
+            SymbolRefByName, View,
+        },
     },
 };
 
@@ -136,7 +139,7 @@ pub fn extab_diff_ui(
         if column == 0 {
             // Left column
             ui.horizontal(|ui| {
-                if ui.button("⏴ Back").clicked() {
+                if ui.button("⏴ Back").clicked() || hotkeys::back_pressed(ui.ctx()) {
                     ret = Some(DiffViewAction::Navigate(DiffViewNavigation::symbol_diff()));
                 }
                 ui.separator();

--- a/objdiff-gui/src/views/extab_diff.rs
+++ b/objdiff-gui/src/views/extab_diff.rs
@@ -235,7 +235,7 @@ pub fn extab_diff_ui(
         }
     });
 
-    hotkeys::check_scroll_hotkeys(ui);
+    hotkeys::check_scroll_hotkeys(ui, true);
 
     // Table
     render_strips(ui, available_width, 2, |ui, column| {

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -14,12 +14,15 @@ use objdiff_core::{
 };
 use time::format_description;
 
-use crate::views::{
-    appearance::Appearance,
-    column_layout::{render_header, render_strips, render_table},
-    symbol_diff::{
-        match_color_for_symbol, symbol_list_ui, DiffViewAction, DiffViewNavigation, DiffViewState,
-        SymbolDiffContext, SymbolFilter, SymbolRefByName, SymbolViewState, View,
+use crate::{
+    hotkeys,
+    views::{
+        appearance::Appearance,
+        column_layout::{render_header, render_strips, render_table},
+        symbol_diff::{
+            match_color_for_symbol, symbol_list_ui, DiffViewAction, DiffViewNavigation,
+            DiffViewState, SymbolDiffContext, SymbolFilter, SymbolRefByName, SymbolViewState, View,
+        },
     },
 };
 
@@ -675,7 +678,7 @@ pub fn function_diff_ui(
         if column == 0 {
             // Left column
             ui.horizontal(|ui| {
-                if ui.button("⏴ Back").clicked() {
+                if ui.button("⏴ Back").clicked() || hotkeys::back_pressed(ui.ctx()) {
                     ret = Some(DiffViewAction::Navigate(DiffViewNavigation::symbol_diff()));
                 }
                 ui.separator();

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -714,10 +714,11 @@ pub fn function_diff_ui(
                         .color(appearance.highlight_color),
                 );
                 if right_ctx.map_or(false, |m| m.has_symbol())
-                    && ui
+                    && (ui
                         .button("Change target")
                         .on_hover_text_at_pointer("Choose a different symbol to use as the target")
                         .clicked()
+                        || hotkeys::consume_change_target_shortcut(ui.ctx()))
                 {
                     if let Some(symbol_ref) = state.symbol_state.right_symbol.as_ref() {
                         ret = Some(DiffViewAction::SelectingLeft(symbol_ref.clone()));
@@ -791,6 +792,7 @@ pub fn function_diff_ui(
                                 "Choose a different symbol to use as the base",
                             )
                             .clicked()
+                            || hotkeys::consume_change_base_shortcut(ui.ctx())
                         {
                             if let Some(symbol_ref) = state.symbol_state.left_symbol.as_ref() {
                                 ret = Some(DiffViewAction::SelectingRight(symbol_ref.clone()));

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -471,6 +471,7 @@ fn asm_table_ui(
             if column == 0 {
                 if let Some(ctx) = left_ctx {
                     if ctx.has_symbol() {
+                        hotkeys::check_scroll_hotkeys(ui, false);
                         render_table(
                             ui,
                             available_width / 2.0,
@@ -532,6 +533,7 @@ fn asm_table_ui(
             } else if column == 1 {
                 if let Some(ctx) = right_ctx {
                     if ctx.has_symbol() {
+                        hotkeys::check_scroll_hotkeys(ui, false);
                         render_table(
                             ui,
                             available_width / 2.0,

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -519,7 +519,7 @@ fn asm_table_ui(
                                 }
                                 DiffViewAction::SetSymbolHighlight(left, right, scroll) => {
                                     symbol_state.highlighted_symbol = (left, right);
-                                    symbol_state.scroll_highlighted_symbol_into_view = scroll;
+                                    symbol_state.scroll_to_highlighted_symbols = (scroll, scroll);
                                 }
                                 _ => {
                                     ret = Some(action);
@@ -581,7 +581,7 @@ fn asm_table_ui(
                                 }
                                 DiffViewAction::SetSymbolHighlight(left, right, scroll) => {
                                     symbol_state.highlighted_symbol = (left, right);
-                                    symbol_state.scroll_highlighted_symbol_into_view = scroll;
+                                    symbol_state.scroll_to_highlighted_symbols = (scroll, scroll);
                                 }
                                 _ => {
                                     ret = Some(action);

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -435,7 +435,7 @@ fn asm_table_ui(
     };
     if left_len.is_some() && right_len.is_some() {
         // Joint view
-        hotkeys::check_scroll_hotkeys(ui);
+        hotkeys::check_scroll_hotkeys(ui, true);
         render_table(
             ui,
             available_width,

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -435,6 +435,7 @@ fn asm_table_ui(
     };
     if left_len.is_some() && right_len.is_some() {
         // Joint view
+        hotkeys::check_scroll_hotkeys(ui);
         render_table(
             ui,
             available_width,

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -409,7 +409,7 @@ fn asm_table_ui(
     right_ctx: Option<FunctionDiffContext<'_>>,
     appearance: &Appearance,
     ins_view_state: &FunctionViewState,
-    symbol_state: &SymbolViewState,
+    symbol_state: &mut SymbolViewState,
 ) -> Option<DiffViewAction> {
     let mut ret = None;
     let left_len = left_ctx.and_then(|ctx| {
@@ -516,8 +516,9 @@ fn asm_table_ui(
                                         SymbolRefByName::new(right_symbol, right_section),
                                     ));
                                 }
-                                DiffViewAction::SetSymbolHighlight(_, _) => {
-                                    // Ignore
+                                DiffViewAction::SetSymbolHighlight(left, right, scroll) => {
+                                    symbol_state.highlighted_symbol = (left, right);
+                                    symbol_state.scroll_highlighted_symbol_into_view = scroll;
                                 }
                                 _ => {
                                     ret = Some(action);
@@ -576,8 +577,9 @@ fn asm_table_ui(
                                         right_symbol_ref,
                                     ));
                                 }
-                                DiffViewAction::SetSymbolHighlight(_, _) => {
-                                    // Ignore
+                                DiffViewAction::SetSymbolHighlight(left, right, scroll) => {
+                                    symbol_state.highlighted_symbol = (left, right);
+                                    symbol_state.scroll_highlighted_symbol_into_view = scroll;
                                 }
                                 _ => {
                                     ret = Some(action);
@@ -620,7 +622,7 @@ impl<'a> FunctionDiffContext<'a> {
 #[must_use]
 pub fn function_diff_ui(
     ui: &mut egui::Ui,
-    state: &DiffViewState,
+    state: &mut DiffViewState,
     appearance: &Appearance,
 ) -> Option<DiffViewAction> {
     let mut ret = None;
@@ -823,7 +825,7 @@ pub fn function_diff_ui(
                 right_ctx,
                 appearance,
                 &state.function_state,
-                &state.symbol_state,
+                &mut state.symbol_state,
             )
         })
         .inner

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -409,7 +409,7 @@ fn asm_table_ui(
     right_ctx: Option<FunctionDiffContext<'_>>,
     appearance: &Appearance,
     ins_view_state: &FunctionViewState,
-    symbol_state: &mut SymbolViewState,
+    symbol_state: &SymbolViewState,
 ) -> Option<DiffViewAction> {
     let mut ret = None;
     let left_len = left_ctx.and_then(|ctx| {
@@ -517,10 +517,6 @@ fn asm_table_ui(
                                         SymbolRefByName::new(right_symbol, right_section),
                                     ));
                                 }
-                                DiffViewAction::SetSymbolHighlight(left, right, scroll) => {
-                                    symbol_state.highlighted_symbol = (left, right);
-                                    symbol_state.scroll_to_highlighted_symbols = (scroll, scroll);
-                                }
                                 _ => {
                                     ret = Some(action);
                                 }
@@ -579,10 +575,6 @@ fn asm_table_ui(
                                         right_symbol_ref,
                                     ));
                                 }
-                                DiffViewAction::SetSymbolHighlight(left, right, scroll) => {
-                                    symbol_state.highlighted_symbol = (left, right);
-                                    symbol_state.scroll_to_highlighted_symbols = (scroll, scroll);
-                                }
                                 _ => {
                                     ret = Some(action);
                                 }
@@ -624,7 +616,7 @@ impl<'a> FunctionDiffContext<'a> {
 #[must_use]
 pub fn function_diff_ui(
     ui: &mut egui::Ui,
-    state: &mut DiffViewState,
+    state: &DiffViewState,
     appearance: &Appearance,
 ) -> Option<DiffViewAction> {
     let mut ret = None;
@@ -829,7 +821,7 @@ pub fn function_diff_ui(
                 right_ctx,
                 appearance,
                 &state.function_state,
-                &mut state.symbol_state,
+                &state.symbol_state,
             )
         })
         .inner

--- a/objdiff-gui/src/views/symbol_diff.rs
+++ b/objdiff-gui/src/views/symbol_diff.rs
@@ -212,7 +212,6 @@ impl DiffViewState {
                     // Ignore action if we're already navigating
                     return;
                 }
-                self.symbol_state.highlighted_symbol = (None, None);
                 let Ok(mut state) = state.write() else {
                     return;
                 };

--- a/objdiff-gui/src/views/symbol_diff.rs
+++ b/objdiff-gui/src/views/symbol_diff.rs
@@ -15,6 +15,7 @@ use regex::{Regex, RegexBuilder};
 
 use crate::{
     app::AppStateRef,
+    hotkeys,
     jobs::{
         create_scratch::{start_create_scratch, CreateScratchConfig, CreateScratchResult},
         objdiff::{BuildStatus, ObjDiffResult},
@@ -534,7 +535,7 @@ fn symbol_ui(
             ret = Some(DiffViewAction::Navigate(result));
         }
     });
-    if response.clicked() {
+    if response.clicked() || (selected && hotkeys::enter_pressed(ui.ctx())) {
         if let Some(section) = section {
             match section.kind {
                 ObjSectionKind::Code => {

--- a/objdiff-gui/src/views/symbol_diff.rs
+++ b/objdiff-gui/src/views/symbol_diff.rs
@@ -649,6 +649,8 @@ pub fn symbol_list_ui(
             }
         }
 
+        hotkeys::check_scroll_hotkeys(ui);
+
         ui.scope(|ui| {
             ui.style_mut().override_text_style = Some(egui::TextStyle::Monospace);
             ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);

--- a/objdiff-gui/src/views/symbol_diff.rs
+++ b/objdiff-gui/src/views/symbol_diff.rs
@@ -898,7 +898,11 @@ pub fn symbol_diff_ui(
             });
 
             let mut search = state.search.clone();
-            if TextEdit::singleline(&mut search).hint_text("Filter symbols").ui(ui).changed() {
+            let response = TextEdit::singleline(&mut search).hint_text("Filter symbols").ui(ui);
+            if hotkeys::consume_symbol_filter_shortcut(ui.ctx()) {
+                response.request_focus();
+            }
+            if response.changed() {
                 ret = Some(DiffViewAction::SetSearch(search));
             }
         } else if column == 1 {

--- a/objdiff-gui/src/views/symbol_diff.rs
+++ b/objdiff-gui/src/views/symbol_diff.rs
@@ -199,6 +199,9 @@ impl DiffViewState {
             ctx.output_mut(|o| o.open_url = Some(OpenUrl::new_tab(result.scratch_url)));
         }
 
+        // Clear the autoscroll flag so that it doesn't scroll continuously.
+        self.symbol_state.autoscroll_to_highlighted_symbols = false;
+
         let Some(action) = action else {
             return;
         };
@@ -540,8 +543,9 @@ fn symbol_ui(
         // Automatically scroll the view to encompass the selected symbol in case the user selected
         // an offscreen symbol by using a keyboard shortcut.
         ui.scroll_to_rect_animation(response.rect, None, ScrollAnimation::none());
-        // This state flag will be reset in App::update at the end of every frame so that we don't
-        // continuously scroll the view back when the user is trying to manually scroll away.
+        // This autoscroll state flag will be reset in DiffViewState::post_update at the end of
+        // every frame so that we don't continuously scroll the view back when the user is trying to
+        // manually scroll away.
     }
     if response.clicked() || (selected && hotkeys::enter_pressed(ui.ctx())) {
         if let Some(section) = section {

--- a/objdiff-gui/src/views/symbol_diff.rs
+++ b/objdiff-gui/src/views/symbol_diff.rs
@@ -561,20 +561,16 @@ fn symbol_ui(
             }
         }
     } else if response.hovered() {
-        ret = Some(if let Some(target_symbol) = symbol_diff.target_symbol {
-            if column == 0 {
-                DiffViewAction::SetSymbolHighlight(
-                    Some(symbol_diff.symbol_ref),
-                    Some(target_symbol),
-                )
-            } else {
-                DiffViewAction::SetSymbolHighlight(
-                    Some(target_symbol),
-                    Some(symbol_diff.symbol_ref),
-                )
-            }
+        ret = Some(if column == 0 {
+            DiffViewAction::SetSymbolHighlight(
+                Some(symbol_diff.symbol_ref),
+                symbol_diff.target_symbol,
+            )
         } else {
-            DiffViewAction::SetSymbolHighlight(None, None)
+            DiffViewAction::SetSymbolHighlight(
+                symbol_diff.target_symbol,
+                Some(symbol_diff.symbol_ref),
+            )
         });
     }
     ret


### PR DESCRIPTION
Keyboard-only navigation demonstration:

https://github.com/user-attachments/assets/6abf4824-ca4d-490a-b259-650a9a096e3e

This PR implements the following keyboard shortcuts:

Symbol list view:
* Enter or Space or Mouse5: Enter the diff view for the symbol that is currently highlighted.
* Up/Down or W/S: Select the symbol above/below the currently selected symbol. If no symbol is highlighted, select the topmost symbol.
* PageUp/PageDown: Scroll up/down by the window height.
* Home/End: Scroll to the top/bottom.
* Ctrl+F: Give focus to the object filter input. (Note: egui's builtin Tab/Shift+Tab/Enter shortcuts already work fine for selecting an object from the filtered list, so I didn't need to add new ones for that.)
* Ctrl+S: Give focus to the symbol filter input.

Function/data/extab diff view:
* Backspace or Escape or Mouse4: Go back to the symbol list.
* Up/Down or W/S: Scroll up/down by 10% of the window height.
* PageUp/PageDown: Scroll up/down by the window height.
* Home/End: Scroll to the top/bottom.

Function diff view only:
* Ctrl+T: Change target function mapped to this base function.
* Ctrl+B: Change base function mapped to this target function.

I also wanted to add a shortcut to open the context menus via the keyboard, but I don't think it's possible in egui :/

Most of these are pretty self-explanatory, but the shortcuts to select the symbol above/below the current one in the listing required a few changes to how objdiff handles the highlighted symbols.
The short version is that the highlighted symbols pair is now treated more like a permanent cursor that you can use to navigate around without the mouse.
Long version:
* The highlighted symbol is no longer cleared when backing out of a diff view. This is to make it easier to re-enter the same symbol you were just diffing, or to go to the one above it, etc.
* When the highlighted symbol is changed via the keyboard, the newly selected symbols will both be scrolled into view one time. When using the mouse, this is not done.
* Using the mouse to highlight a symbol that has no counterpart on the opposite side now gives it a blue (permanent) highlight like other symbols, instead of just a grey (temporary) highlight. This is so you can start by selecting a symbol with the mouse, and then move the cursor around with the keyboard to continue selecting other symbols.

Also, the "split view" where half the window is the function view and the other half is the symbol list view is supported. The symbol list's shortcuts work normally here, while the function diff half has the up/down shortcuts disabled so it doesn't scroll accidentally while navigating the symbol list, but the PageUp/PageDown/Home/End shortcuts are still enabled in case you do want to scroll the function diff in the split view.

Let me know if anything could be improved!