### PR TITLE
Display decoded rlwinm info to hover tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ android.keystore
 *.frag
 *.vert
 *.metal
-.vscode/launch.json
+.vscode/

--- a/objdiff-gui/Cargo.toml
+++ b/objdiff-gui/Cargo.toml
@@ -95,7 +95,7 @@ exec = "0.3"
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -151,7 +151,7 @@ fn ins_hover_ui(
         }
 
         if let Some(demangled) = rlwinmdec::decode(&ins.formatted) {
-            ui.colored_label(appearance.highlight_color, &demangled);
+            ui.colored_label(appearance.highlight_color, demangled.trim());
         }
     });
 }

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -150,8 +150,8 @@ fn ins_hover_ui(
             }
         }
 
-        if let Some(demangled) = rlwinmdec::decode(&ins.formatted) {
-            ui.colored_label(appearance.highlight_color, demangled.trim());
+        if let Some(decoded) = rlwinmdec::decode(&ins.formatted) {
+            ui.colored_label(appearance.highlight_color, decoded.trim());
         }
     });
 }

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -149,6 +149,10 @@ fn ins_hover_ui(
                 ui.colored_label(appearance.highlight_color, "Extern".to_string());
             }
         }
+
+        if let Some(demangled) = rlwinmdec::decode(&ins.formatted) {
+            ui.colored_label(appearance.highlight_color, &demangled);
+        }
     });
 }
 

--- a/objdiff-gui/src/views/rlwinm.rs
+++ b/objdiff-gui/src/views/rlwinm.rs
@@ -19,7 +19,7 @@ pub fn rlwinm_decode_window(
         if let Some(demangled) = rlwinmdec::decode(&state.text) {
             ui.scope(|ui| {
                 ui.style_mut().override_text_style = Some(TextStyle::Monospace);
-                ui.colored_label(appearance.replace_color, &demangled);
+                ui.colored_label(appearance.replace_color, demangled.trim());
             });
             if ui.button("Copy").clicked() {
                 ui.output_mut(|output| output.copied_text = demangled);

--- a/objdiff-gui/src/views/rlwinm.rs
+++ b/objdiff-gui/src/views/rlwinm.rs
@@ -16,13 +16,13 @@ pub fn rlwinm_decode_window(
     egui::Window::new("Rlwinm Decoder").open(show).show(ctx, |ui| {
         ui.text_edit_singleline(&mut state.text);
         ui.add_space(10.0);
-        if let Some(demangled) = rlwinmdec::decode(&state.text) {
+        if let Some(decoded) = rlwinmdec::decode(&state.text) {
             ui.scope(|ui| {
                 ui.style_mut().override_text_style = Some(TextStyle::Monospace);
-                ui.colored_label(appearance.replace_color, demangled.trim());
+                ui.colored_label(appearance.replace_color, decoded.trim());
             });
             if ui.button("Copy").clicked() {
-                ui.output_mut(|output| output.copied_text = demangled);
+                ui.output_mut(|output| output.copied_text = decoded);
             }
         } else {
             ui.scope(|ui| {


### PR DESCRIPTION
![2024-12-01_20_32_53_023_objdiff](https://github.com/user-attachments/assets/bde65097-2445-4053-bcbf-7c06e2fdc69f)

Small feature to integrate the rlwinm decoder window with the instruction hover tooltip to save some time copy pasting the instruction.

I also removed the trailing newline returned by `decode` when showing that info to avoid it using up one extra line of space.