### PR TITLE
Add buttons to collapse or expand all sections in the symbol list view for an object simultaneously

### DIFF
--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -512,6 +512,7 @@ fn asm_table_ui(
                             SymbolFilter::Mapping(right_symbol_ref),
                             appearance,
                             column,
+                            None,
                         ) {
                             match action {
                                 DiffViewAction::Navigate(DiffViewNavigation {
@@ -570,6 +571,7 @@ fn asm_table_ui(
                             SymbolFilter::Mapping(left_symbol_ref),
                             appearance,
                             column,
+                            None,
                         ) {
                             match action {
                                 DiffViewAction::Navigate(DiffViewNavigation {


### PR DESCRIPTION
This adds two buttons on each side of the symbol list that speed up the process of collapsing sections so you don't have to click each section header one at a time.

![image](https://github.com/user-attachments/assets/8b910edb-5e42-4533-9a46-2ac6db8fcbac)

This isn't needed for 99% of objects, but rare objects like d_a_player_main have so many sections that doing them one by one is extremely tedious. Usually you'd use "Filter symbols" to find one specific function, but sometimes you want to compare an entire section because of weak function ordering issues or similar.

Also supports the split view for consistency, though I'm not sure if this feature has any use in that view.

![image](https://github.com/user-attachments/assets/521262d1-87b9-46d5-bf4b-c004e45fe10f)
