### PR TITLE
Implement diffing relocations within data sections

### DIFF
--- a/objdiff-core/src/arch/arm.rs
+++ b/objdiff-core/src/arch/arm.rs
@@ -276,6 +276,19 @@ impl ObjArch for ObjArchArm {
     fn display_reloc(&self, flags: RelocationFlags) -> Cow<'static, str> {
         Cow::Owned(format!("<{flags:?}>"))
     }
+
+    fn get_reloc_byte_size(&self, flags: RelocationFlags) -> usize {
+        match flags {
+            RelocationFlags::Elf { r_type } => match r_type {
+                elf::R_ARM_ABS32 => 4,
+                elf::R_ARM_REL32 => 4,
+                elf::R_ARM_ABS16 => 2,
+                elf::R_ARM_ABS8 => 1,
+                _ => 1,
+            },
+            _ => 1,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/objdiff-core/src/arch/arm64.rs
+++ b/objdiff-core/src/arch/arm64.rs
@@ -173,6 +173,21 @@ impl ObjArch for ObjArchArm64 {
             _ => Cow::Owned(format!("<{flags:?}>")),
         }
     }
+
+    fn get_reloc_byte_size(&self, flags: RelocationFlags) -> usize {
+        match flags {
+            RelocationFlags::Elf { r_type } => match r_type {
+                elf::R_AARCH64_ABS64 => 8,
+                elf::R_AARCH64_ABS32 => 4,
+                elf::R_AARCH64_ABS16 => 2,
+                elf::R_AARCH64_PREL64 => 8,
+                elf::R_AARCH64_PREL32 => 4,
+                elf::R_AARCH64_PREL16 => 2,
+                _ => 1,
+            },
+            _ => 1,
+        }
+    }
 }
 
 struct DisplayCtx<'a> {

--- a/objdiff-core/src/arch/mips.rs
+++ b/objdiff-core/src/arch/mips.rs
@@ -271,6 +271,17 @@ impl ObjArch for ObjArchMips {
             _ => Cow::Owned(format!("<{flags:?}>")),
         }
     }
+
+    fn get_reloc_byte_size(&self, flags: RelocationFlags) -> usize {
+        match flags {
+            RelocationFlags::Elf { r_type } => match r_type {
+                elf::R_MIPS_16 => 2,
+                elf::R_MIPS_32 => 4,
+                _ => 1,
+            },
+            _ => 1,
+        }
+    }
 }
 
 fn push_reloc(args: &mut Vec<ObjInsArg>, reloc: &ObjReloc) -> Result<()> {

--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -148,6 +148,8 @@ pub trait ObjArch: Send + Sync {
 
     fn display_reloc(&self, flags: RelocationFlags) -> Cow<'static, str>;
 
+    fn get_reloc_byte_size(&self, flags: RelocationFlags) -> usize;
+
     fn symbol_address(&self, symbol: &Symbol) -> u64 { symbol.address() }
 
     fn guess_data_type(&self, _instruction: &ObjIns) -> Option<DataType> { None }

--- a/objdiff-core/src/arch/ppc.rs
+++ b/objdiff-core/src/arch/ppc.rs
@@ -193,6 +193,17 @@ impl ObjArch for ObjArchPpc {
         }
     }
 
+    fn get_reloc_byte_size(&self, flags: RelocationFlags) -> usize {
+        match flags {
+            RelocationFlags::Elf { r_type } => match r_type {
+                elf::R_PPC_ADDR32 => 4,
+                elf::R_PPC_UADDR32 => 4,
+                _ => 1,
+            },
+            _ => 1,
+        }
+    }
+
     fn guess_data_type(&self, instruction: &ObjIns) -> Option<super::DataType> {
         if instruction.reloc.as_ref().is_some_and(|r| r.target.name.starts_with("@stringBase")) {
             return Some(DataType::String);

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -162,6 +162,19 @@ impl ObjArch for ObjArchX86 {
             _ => Cow::Owned(format!("<{flags:?}>")),
         }
     }
+
+    fn get_reloc_byte_size(&self, flags: RelocationFlags) -> usize {
+        match flags {
+            RelocationFlags::Coff { typ } => match typ {
+                pe::IMAGE_REL_I386_DIR16 => 2,
+                pe::IMAGE_REL_I386_REL16 => 2,
+                pe::IMAGE_REL_I386_DIR32 => 4,
+                pe::IMAGE_REL_I386_REL32 => 4,
+                _ => 1,
+            },
+            _ => 1,
+        }
+    }
 }
 
 fn replace_arg(

--- a/objdiff-core/src/diff/code.rs
+++ b/objdiff-core/src/diff/code.rs
@@ -192,7 +192,7 @@ fn address_eq(left: &ObjReloc, right: &ObjReloc) -> bool {
     left.target.address as i64 + left.addend == right.target.address as i64 + right.addend
 }
 
-fn section_name_eq(
+pub fn section_name_eq(
     left_obj: &ObjInfo,
     right_obj: &ObjInfo,
     left_orig_section_index: usize,

--- a/objdiff-core/src/diff/data.rs
+++ b/objdiff-core/src/diff/data.rs
@@ -177,7 +177,7 @@ pub fn diff_data_section(
             }
         };
         if kind == ObjDataDiffKind::None {
-            let mut found_any_reloc_diffs = false;
+            let mut found_any_relocs = false;
             let mut left_curr_addr = left_range.start;
             let mut right_curr_addr = right_range.start;
             for (diff_kind, left_reloc, right_reloc) in diff_data_relocs_for_range(
@@ -188,10 +188,7 @@ pub fn diff_data_section(
                 left_range.clone(),
                 right_range.clone(),
             ) {
-                if diff_kind == ObjDataDiffKind::None {
-                    continue;
-                }
-                found_any_reloc_diffs = true;
+                found_any_relocs = true;
 
                 if let Some(left_reloc) = left_reloc {
                     let left_reloc_addr = left_reloc.address as usize;
@@ -243,7 +240,7 @@ pub fn diff_data_section(
                 }
             }
 
-            if found_any_reloc_diffs {
+            if found_any_relocs {
                 if left_curr_addr < left_range.end - 1 {
                     let len = left_range.end - left_curr_addr;
                     let left_data = &left.data[left_curr_addr..left_range.end];

--- a/objdiff-core/src/diff/mod.rs
+++ b/objdiff-core/src/diff/mod.rs
@@ -349,6 +349,8 @@ pub fn diff_objs(
                     let left_section_diff = left_out.section_diff(left_section_idx);
                     let right_section_diff = right_out.section_diff(right_section_idx);
                     let (left_diff, right_diff) = diff_data_section(
+                        left_obj,
+                        right_obj,
                         left_section,
                         right_section,
                         left_section_diff,

--- a/objdiff-core/src/diff/mod.rs
+++ b/objdiff-core/src/diff/mod.rs
@@ -11,7 +11,9 @@ use crate::{
             diff_generic_section, no_diff_symbol,
         },
     },
-    obj::{ObjInfo, ObjIns, ObjSection, ObjSectionKind, ObjSymbol, SymbolRef, SECTION_COMMON},
+    obj::{
+        ObjInfo, ObjIns, ObjReloc, ObjSection, ObjSectionKind, ObjSymbol, SymbolRef, SECTION_COMMON,
+    },
 };
 
 pub mod code;
@@ -85,6 +87,7 @@ pub struct ObjDataDiff {
     pub kind: ObjDataDiffKind,
     pub len: usize,
     pub symbol: String,
+    pub reloc: Option<ObjReloc>,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
@@ -153,6 +156,7 @@ impl ObjDiff {
                     kind: ObjDataDiffKind::None,
                     len: section.data.len(),
                     symbol: section.name.clone(),
+                    ..Default::default()
                 }],
                 match_percent: None,
             });

--- a/objdiff-gui/src/views/data_diff.rs
+++ b/objdiff-gui/src/views/data_diff.rs
@@ -117,8 +117,8 @@ fn split_diffs(diffs: &[ObjDataDiff]) -> Vec<Vec<ObjDataDiff>> {
                 },
                 kind: diff.kind,
                 len,
-                // TODO
-                symbol: String::new(),
+                symbol: String::new(), // TODO
+                reloc: diff.reloc.clone(),
             });
             remaining_in_row -= len;
             cur_len += len;

--- a/objdiff-gui/src/views/data_diff.rs
+++ b/objdiff-gui/src/views/data_diff.rs
@@ -79,6 +79,32 @@ fn data_row_hover_ui(
     });
 }
 
+fn data_row_context_menu(ui: &mut egui::Ui, diffs: &[ObjDataDiff]) {
+    ui.scope(|ui| {
+        ui.style_mut().override_text_style = Some(egui::TextStyle::Monospace);
+        ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
+        for diff in diffs {
+            let Some(reloc) = &diff.reloc else {
+                continue;
+            };
+
+            // TODO: This code is copy-pasted from ins_context_menu.
+            // Try to separate this out into a shared function.
+            if let Some(name) = &reloc.target.demangled_name {
+                if ui.button(format!("Copy \"{name}\"")).clicked() {
+                    ui.output_mut(|output| output.copied_text.clone_from(name));
+                    ui.close_menu();
+                }
+            }
+            if ui.button(format!("Copy \"{}\"", reloc.target.name)).clicked() {
+                ui.output_mut(|output| output.copied_text.clone_from(&reloc.target.name));
+                ui.close_menu();
+            }
+        }
+    });
+}
+
 fn data_row_ui(
     ui: &mut egui::Ui,
     obj: Option<&ObjInfo>,
@@ -159,8 +185,9 @@ fn data_row_ui(
 
     let response = Label::new(job).sense(Sense::click()).ui(ui);
     if let Some(obj) = obj {
-        response.on_hover_ui_at_pointer(|ui| data_row_hover_ui(ui, obj, diffs, appearance));
-        // .context_menu(|ui| data_row_context_menu(ui, ins)); // TODO
+        response
+            .on_hover_ui_at_pointer(|ui| data_row_hover_ui(ui, obj, diffs, appearance))
+            .context_menu(|ui| data_row_context_menu(ui, diffs));
     }
 }
 

--- a/objdiff-gui/src/views/data_diff.rs
+++ b/objdiff-gui/src/views/data_diff.rs
@@ -42,6 +42,12 @@ fn data_row_hover_ui(
                 continue;
             };
 
+            // Use a slightly different font color for nonmatching relocations so they stand out.
+            let color = match diff.kind {
+                ObjDataDiffKind::None => appearance.highlight_color,
+                _ => appearance.replace_color,
+            };
+
             // TODO: Most of this code is copy-pasted from ins_hover_ui.
             // Try to separate this out into a shared function.
             ui.label(format!("Relocation type: {}", obj.arch.display_reloc(reloc.flags)));
@@ -50,30 +56,21 @@ fn data_row_hover_ui(
                 Ordering::Less => format!("-{:x}", -reloc.addend),
                 _ => "".to_string(),
             };
-            ui.colored_label(
-                appearance.highlight_color,
-                format!("Name: {}{}", reloc.target.name, addend_str),
-            );
+            ui.colored_label(color, format!("Name: {}{}", reloc.target.name, addend_str));
             if let Some(orig_section_index) = reloc.target.orig_section_index {
                 if let Some(section) =
                     obj.sections.iter().find(|s| s.orig_index == orig_section_index)
                 {
-                    ui.colored_label(
-                        appearance.highlight_color,
-                        format!("Section: {}", section.name),
-                    );
+                    ui.colored_label(color, format!("Section: {}", section.name));
                 }
                 ui.colored_label(
-                    appearance.highlight_color,
+                    color,
                     format!("Address: {:x}{}", reloc.target.address, addend_str),
                 );
-                ui.colored_label(
-                    appearance.highlight_color,
-                    format!("Size: {:x}", reloc.target.size),
-                );
+                ui.colored_label(color, format!("Size: {:x}", reloc.target.size));
                 if reloc.addend >= 0 && reloc.target.bytes.len() > reloc.addend as usize {}
             } else {
-                ui.colored_label(appearance.highlight_color, "Extern".to_string());
+                ui.colored_label(color, "Extern".to_string());
             }
         }
     });


### PR DESCRIPTION
Because objdiff does not link the base object, and it only compares the raw bytes of data sections with each other, any differing relocations inside data will not show as a diff in the current version of objdiff. This can make them difficult to fix. And for objects that can't be linked and have their hash checked due to other reasons like regalloc or weak function ordering, it can be nearly impossible to even know when these issues exist in the first place, which can result in objects that appear equivalent but have nonequivalent relocations.

Some common cases where this can happen include*:
* Arrays of function pointers
* PTMF literals
* Jump tables used by switch statements

To help avoid this issue, this PR implements diffing for relocations in data.

---

In the data diff view, bytes that contain relocations that don't match will show highlighted as different, even though the bytes themselves (00) are the same:
![image](https://github.com/user-attachments/assets/a3a1d607-ca22-47d3-a57b-ad662eb1e825)

Hovering over a row that contains at least one relocation will show all relocations in that row on that side (both matching and nonmatching relocations):
![image](https://github.com/user-attachments/assets/bca51a17-eef4-424a-9510-15377dc92bee)
Which specific byte the user hovered over can't be detected, so multiple relocations in a single line will be shown together (hopefully this isn't too confusing).

You can also right click a reloc to copy its target symbol name:
![image](https://github.com/user-attachments/assets/abb23fcc-8cd1-4fb0-bbde-2e6083af49ba)

---

In the symbol listing view, paired symbols that don't have matching relocations with their counterpart will show less than 100%:
![image](https://github.com/user-attachments/assets/288dbfbf-34bb-49cf-9433-9248db8ab36c)
Specifically, each byte containing a relocation will be counted twice for the percentage: once for if the value of the unlinked byte itself matches, and a second time for if the relocation matches.

The section's overall match percent will look at the entire section, not each individual symbol. This means that the section may show less than 100% even when each individual symbol's relocations match 100% when the symbols are out of order in the section, such as weak vtables:
![image](https://github.com/user-attachments/assets/794b1115-315c-4f82-aac3-cbe7d3bcad99)

---

When vtables are not out of order, but instead there are weak stripped vtables in the middle of the section, the diff looks a bit weird:
![image](https://github.com/user-attachments/assets/fbc76556-556d-4801-9708-abf8d1cecae8)
It shows a bunch of diffs here because the vtables are shifted, and so its diffing the stripped vtables with the unstripped vtables (this is a result of objdiff showing the entire section at once in the data diff view).
But I don't think this is a big deal as it doesn't show any diffs when you go back to the symbol list view, this is the same object:
![image](https://github.com/user-attachments/assets/ef1aaede-903c-439b-aaec-a35651010aac)

---

I've only tested this for PPC architecture. In theory it should work on other architectures too, as I added arch-specific code to detect how many bytes each relocation takes up, but I'm not sure.

(*Specific examples of these issues that were found and fixed while testing this PR can be seen here https://github.com/zeldaret/tww/commit/8e44641465413ba98ebf02bc1faa60d904d3a165 and here https://github.com/zeldaret/tp/commit/2189777abfd60d8c1b9afbcc63f7c6e007f6e37e)
