### PR TITLE
Check relocation addends when diffing functions

### DIFF
--- a/objdiff-cli/src/views/function_diff.rs
+++ b/objdiff-cli/src/views/function_diff.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use anyhow::{bail, Result};
 use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind};
 use objdiff_core::{
@@ -557,6 +559,18 @@ impl FunctionDiffUi {
                     DiffText::Symbol(sym, diff) => {
                         let name = sym.demangled_name.as_ref().unwrap_or(&sym.name);
                         label_text = name.clone();
+                        if let Some(diff) = diff {
+                            base_color = COLOR_ROTATION[diff.idx % COLOR_ROTATION.len()]
+                        } else {
+                            base_color = Color::White;
+                        }
+                    }
+                    DiffText::Addend(addend, diff) => {
+                        label_text = match addend.cmp(&0i64) {
+                            Ordering::Greater => format!("+{:#x}", addend),
+                            Ordering::Less => format!("-{:#x}", -addend),
+                            _ => "".to_string(),
+                        };
                         if let Some(diff) = diff {
                             base_color = COLOR_ROTATION[diff.idx % COLOR_ROTATION.len()]
                         } else {

--- a/objdiff-core/src/diff/display.rs
+++ b/objdiff-core/src/diff/display.rs
@@ -1,5 +1,3 @@
-use std::cmp::Ordering;
-
 use crate::{
     diff::{ObjInsArgDiff, ObjInsDiff},
     obj::{ObjInsArg, ObjInsArgValue, ObjReloc, ObjSymbol},
@@ -23,6 +21,8 @@ pub enum DiffText<'a> {
     BranchDest(u64, Option<&'a ObjInsArgDiff>),
     /// Symbol name
     Symbol(&'a ObjSymbol, Option<&'a ObjInsArgDiff>),
+    /// Relocation addend
+    Addend(i64, Option<&'a ObjInsArgDiff>),
     /// Number of spaces
     Spacing(usize),
     /// End of line
@@ -99,11 +99,7 @@ fn display_reloc_name<E>(
     diff: Option<&ObjInsArgDiff>,
 ) -> Result<(), E> {
     cb(DiffText::Symbol(&reloc.target, diff))?;
-    match reloc.addend.cmp(&0i64) {
-        Ordering::Greater => cb(DiffText::Basic(&format!("+{:#x}", reloc.addend))),
-        Ordering::Less => cb(DiffText::Basic(&format!("-{:#x}", -reloc.addend))),
-        _ => Ok(()),
-    }
+    cb(DiffText::Addend(reloc.addend, diff))
 }
 
 impl PartialEq<DiffText<'_>> for HighlightKind {

--- a/objdiff-gui/src/views/function_diff.rs
+++ b/objdiff-gui/src/views/function_diff.rs
@@ -312,6 +312,18 @@ fn diff_text_ui(
                 base_color = appearance.emphasized_text_color;
             }
         }
+        DiffText::Addend(addend, diff) => {
+            label_text = match addend.cmp(&0i64) {
+                Ordering::Greater => format!("+{:#x}", addend),
+                Ordering::Less => format!("-{:#x}", -addend),
+                _ => "".to_string(),
+            };
+            if let Some(diff) = diff {
+                base_color = appearance.diff_colors[diff.idx % appearance.diff_colors.len()]
+            } else {
+                base_color = appearance.emphasized_text_color;
+            }
+        }
         DiffText::Spacing(n) => {
             ui.add_space(n as f32 * space_width);
             return ret;


### PR DESCRIPTION
This is probably pretty rare and not that important, but I ran into a case where the (fake) relocation shown by objdiff had the correct symbol name but wrong addend, and objdiff wasn't highlighting it as a diff like it should be, so I implemented that. This also makes the func reloc diffing logic more similar to the data reloc diffing logic (which already checks addends).

Before:
![image](https://github.com/user-attachments/assets/25d1c095-66b5-4225-9549-7732ffdfa19b)
After:
![image](https://github.com/user-attachments/assets/e33eb57c-87a8-4000-a306-402732d34dda)

Also the second commit is to make the addend be visually colored along with the symbol:
![image](https://github.com/user-attachments/assets/4851d3a8-facf-4072-b99d-2e23238904c6)
