### PR TITLE
Fix added/removed bytes being visually misaligned in data diff view

### DIFF
--- a/objdiff-gui/src/views/data_diff.rs
+++ b/objdiff-gui/src/views/data_diff.rs
@@ -149,7 +149,9 @@ fn data_row_ui(
         let base_color = get_color_for_diff_kind(diff.kind, appearance);
         if diff.data.is_empty() {
             let mut str = "   ".repeat(diff.len);
-            str.push_str(" ".repeat(diff.len / 8).as_str());
+            let n1 = cur_addr / 8;
+            let n2 = (diff.len + cur_addr) / 8;
+            str.push_str(" ".repeat(n2 - n1).as_str());
             write_text(str.as_str(), base_color, &mut job, appearance.code_font.clone());
             cur_addr += diff.len;
         } else {


### PR DESCRIPTION
`diff.len / 8` doesn't always catch when the 8-byte column midpoint is passed since e.g. when `cur_addr=4` `diff.len=5` neither one of those are greater than 8 individually, but are combined.

Before:
![image](https://github.com/user-attachments/assets/92061bbb-c192-41f4-9e35-c077aaab2b89)

After:
![image](https://github.com/user-attachments/assets/bd99ffa7-c850-4fa3-932d-ea9620859f3a)
