### PR TITLE
Reimplement colorized data relocation hover diffs

### DIFF
--- a/objdiff-gui/src/views/data_diff.rs
+++ b/objdiff-gui/src/views/data_diff.rs
@@ -19,6 +19,7 @@ fn data_row_hover(obj: &Object, diffs: &[(DataDiff, Vec<DataRelocationDiff>)]) -
     let mut out = Vec::new();
     let reloc_diffs = diffs.iter().flat_map(|(_, reloc_diffs)| reloc_diffs);
     let mut prev_reloc = None;
+    let mut first = true;
     for reloc_diff in reloc_diffs {
         let reloc = &reloc_diff.reloc;
         if prev_reloc == Some(reloc) {
@@ -29,10 +30,16 @@ fn data_row_hover(obj: &Object, diffs: &[(DataDiff, Vec<DataRelocationDiff>)]) -
         }
         prev_reloc = Some(reloc);
 
+        if first {
+            first = false;
+        } else {
+            out.push(HoverItem::Separator);
+        }
+
         let color = get_hover_item_color_for_diff_kind(reloc_diff.kind);
 
         let reloc = resolve_relocation(&obj.symbols, reloc);
-        out.append(&mut relocation_hover(obj, reloc, color));
+        out.append(&mut relocation_hover(obj, reloc, Some(color)));
     }
     out
 }

--- a/objdiff-gui/src/views/data_diff.rs
+++ b/objdiff-gui/src/views/data_diff.rs
@@ -5,7 +5,7 @@ use objdiff_core::{
     diff::{
         DataDiff, DataDiffKind, DataRelocationDiff,
         data::resolve_relocation,
-        display::{ContextItem, HoverItem, relocation_context, relocation_hover},
+        display::{ContextItem, HoverItem, HoverItemColor, relocation_context, relocation_hover},
     },
     obj::Object,
 };
@@ -29,11 +29,10 @@ fn data_row_hover(obj: &Object, diffs: &[(DataDiff, Vec<DataRelocationDiff>)]) -
         }
         prev_reloc = Some(reloc);
 
-        // TODO: Change hover text color depending on Insert/Delete/Replace kind
-        // let color = get_color_for_diff_kind(reloc_diff.kind, appearance);
+        let color = get_hover_item_color_for_diff_kind(reloc_diff.kind);
 
         let reloc = resolve_relocation(&obj.symbols, reloc);
-        out.append(&mut relocation_hover(obj, reloc));
+        out.append(&mut relocation_hover(obj, reloc, color));
     }
     out
 }
@@ -94,6 +93,15 @@ fn get_color_for_diff_kind(diff_kind: DataDiffKind, appearance: &Appearance) -> 
         DataDiffKind::Replace => appearance.replace_color,
         DataDiffKind::Delete => appearance.delete_color,
         DataDiffKind::Insert => appearance.insert_color,
+    }
+}
+
+fn get_hover_item_color_for_diff_kind(diff_kind: DataDiffKind) -> HoverItemColor {
+    match diff_kind {
+        DataDiffKind::None => HoverItemColor::Normal,
+        DataDiffKind::Replace => HoverItemColor::Special,
+        DataDiffKind::Delete => HoverItemColor::Delete,
+        DataDiffKind::Insert => HoverItemColor::Insert,
     }
 }
 

--- a/objdiff-gui/src/views/diff.rs
+++ b/objdiff-gui/src/views/diff.rs
@@ -795,6 +795,8 @@ pub fn hover_items_ui(ui: &mut Ui, items: Vec<HoverItem>, appearance: &Appearanc
                 if !label.is_empty() {
                     let label_color = match color {
                         HoverItemColor::Special => appearance.replace_color,
+                        HoverItemColor::Delete => appearance.delete_color,
+                        HoverItemColor::Insert => appearance.insert_color,
                         _ => appearance.highlight_color,
                     };
                     write_text(&label, label_color, &mut job, appearance.code_font.clone());

--- a/objdiff-gui/src/views/symbol_diff.rs
+++ b/objdiff-gui/src/views/symbol_diff.rs
@@ -8,8 +8,8 @@ use objdiff_core::{
     diff::{
         ObjectDiff, SymbolDiff,
         display::{
-            HighlightKind, SectionDisplay, SymbolFilter, SymbolNavigationKind, display_sections,
-            symbol_context, symbol_hover,
+            HighlightKind, HoverItemColor, SectionDisplay, SymbolFilter, SymbolNavigationKind,
+            display_sections, symbol_context, symbol_hover,
         },
     },
     jobs::{Job, JobQueue, JobResult, create_scratch::CreateScratchResult, objdiff::ObjDiffResult},
@@ -512,7 +512,11 @@ pub fn symbol_hover_ui(
     ui.scope(|ui| {
         ui.style_mut().override_text_style = Some(egui::TextStyle::Monospace);
         ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
-        hover_items_ui(ui, symbol_hover(ctx.obj, symbol_idx, 0), appearance);
+        hover_items_ui(
+            ui,
+            symbol_hover(ctx.obj, symbol_idx, 0, HoverItemColor::Normal),
+            appearance,
+        );
     });
 }
 

--- a/objdiff-gui/src/views/symbol_diff.rs
+++ b/objdiff-gui/src/views/symbol_diff.rs
@@ -8,8 +8,8 @@ use objdiff_core::{
     diff::{
         ObjectDiff, SymbolDiff,
         display::{
-            HighlightKind, HoverItemColor, SectionDisplay, SymbolFilter, SymbolNavigationKind,
-            display_sections, symbol_context, symbol_hover,
+            HighlightKind, SectionDisplay, SymbolFilter, SymbolNavigationKind, display_sections,
+            symbol_context, symbol_hover,
         },
     },
     jobs::{Job, JobQueue, JobResult, create_scratch::CreateScratchResult, objdiff::ObjDiffResult},
@@ -512,11 +512,7 @@ pub fn symbol_hover_ui(
     ui.scope(|ui| {
         ui.style_mut().override_text_style = Some(egui::TextStyle::Monospace);
         ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
-        hover_items_ui(
-            ui,
-            symbol_hover(ctx.obj, symbol_idx, 0, HoverItemColor::Normal),
-            appearance,
-        );
+        hover_items_ui(ui, symbol_hover(ctx.obj, symbol_idx, 0, None), appearance);
     });
 }
 

--- a/objdiff-wasm/src/api.rs
+++ b/objdiff-wasm/src/api.rs
@@ -230,10 +230,15 @@ impl GuestDisplay for Component {
     ) -> Vec<HoverItem> {
         let obj_diff = diff.get::<ResourceObjectDiff>();
         let obj = obj_diff.0.as_ref();
-        diff::display::symbol_hover(obj, symbol_display.symbol as usize, 0 /* TODO */)
-            .into_iter()
-            .map(|item| HoverItem::from(item))
-            .collect()
+        diff::display::symbol_hover(
+            obj,
+            symbol_display.symbol as usize,
+            0,
+            diff::display::HoverItemColor::Normal, // TODO: colorize replaced/deleted/inserted relocations
+        )
+        .into_iter()
+        .map(|item| HoverItem::from(item))
+        .collect()
     }
 
     fn instruction_context(
@@ -501,6 +506,8 @@ impl From<diff::display::HoverItemColor> for HoverItemColor {
             diff::display::HoverItemColor::Normal => HoverItemColor::Normal,
             diff::display::HoverItemColor::Emphasized => HoverItemColor::Emphasized,
             diff::display::HoverItemColor::Special => HoverItemColor::Special,
+            diff::display::HoverItemColor::Delete => HoverItemColor::Delete,
+            diff::display::HoverItemColor::Insert => HoverItemColor::Insert,
         }
     }
 }

--- a/objdiff-wasm/src/api.rs
+++ b/objdiff-wasm/src/api.rs
@@ -230,15 +230,12 @@ impl GuestDisplay for Component {
     ) -> Vec<HoverItem> {
         let obj_diff = diff.get::<ResourceObjectDiff>();
         let obj = obj_diff.0.as_ref();
-        diff::display::symbol_hover(
-            obj,
-            symbol_display.symbol as usize,
-            0,
-            diff::display::HoverItemColor::Normal, // TODO: colorize replaced/deleted/inserted relocations
-        )
-        .into_iter()
-        .map(|item| HoverItem::from(item))
-        .collect()
+        // TODO: colorize replaced/deleted/inserted relocations
+        let override_color = None;
+        diff::display::symbol_hover(obj, symbol_display.symbol as usize, 0, override_color)
+            .into_iter()
+            .map(|item| HoverItem::from(item))
+            .collect()
     }
 
     fn instruction_context(

--- a/objdiff-wasm/wit/objdiff.wit
+++ b/objdiff-wasm/wit/objdiff.wit
@@ -137,6 +137,8 @@ interface display {
     normal,
     emphasized,
     special,
+    delete,
+    insert,
   }
 
   record hover-item-text {


### PR DESCRIPTION
#154 https://github.com/encounter/objdiff/pull/154/commits/161dadd21325f44a7d55597d7a916f75fa0d925a Change font color for nonmatching relocs on hover

![image](https://github.com/user-attachments/assets/99779273-a5f4-4eeb-aa39-4e6a556535e9)
