### PR TITLE
ARM: Fix subtract with overflow error when no mapping symbol at address 0

### DIFF
--- a/objdiff-core/src/arch/arm.rs
+++ b/objdiff-core/src/arch/arm.rs
@@ -199,7 +199,7 @@ impl Arch for ArchArm {
             .unwrap_or(&fallback_mappings);
         let first_mapping_idx = mapping_symbols
             .binary_search_by_key(&start_addr, |x| x.address)
-            .unwrap_or_else(|idx| idx - 1);
+            .unwrap_or_else(|idx| idx.saturating_sub(1));
         let mut mode = mapping_symbols[first_mapping_idx].mapping;
 
         let mut mappings_iter = mapping_symbols


### PR DESCRIPTION
Fixes #176. It looks like the root cause of that regression is that objdiff 3 now infers that 0-size symbols are larger than they really are if junk(?) data comes right after them, so objdiff guess that these 0x68 bytes are a function called ".text". objdiff 2 just skipped over it because it had size 0 and unknown type.

Since it's not clear if this object is even valid I think a quick fix that just avoids the build error is fine in this case so that it can be viewed.

![image](https://github.com/user-attachments/assets/96dc681c-8ea5-416c-b87d-94b25fecdc7e)
![image](https://github.com/user-attachments/assets/c3a1a592-64ed-408f-b9de-4e1516c6a2e6)
