### PR TITLE
PPC: Fix pooled relocation addends being added twice sometimes

### DIFF
--- a/objdiff-core/src/arch/ppc.rs
+++ b/objdiff-core/src/arch/ppc.rs
@@ -513,6 +513,7 @@ fn guess_data_type_from_load_store_inst_op(inst_op: ppc750cl::Opcode) -> Option<
     }
 }
 
+#[derive(Debug)]
 struct PoolReference {
     addr_src_gpr: ppc750cl::GPR,
     addr_offset: i16,
@@ -645,7 +646,7 @@ fn make_fake_pool_reloc(
         // example, dCcD_Cyl in The Wind Waker). So just showing that vtable symbol plus an addend
         // to represent the offset into it works fine in this case.
         target_symbol = pool_reloc.relocation.target_symbol;
-        addend = pool_reloc.relocation.addend + offset_from_pool;
+        addend = offset_from_pool;
     }
     Some(Relocation {
         flags: RelocationFlags::Elf(elf::R_PPC_NONE),


### PR DESCRIPTION
My original pooled relocations implementation had a bug where it wasn't adding multiple addends together when calculating fake relocations:
![image](https://github.com/user-attachments/assets/4be559b6-584a-4524-b0ea-01c01db27694)
Both sides should resolve to `g_dComIfG_gameInfo+0x529c`, but instead one showed `g_dComIfG_gameInfo+0x51d8` and the other showed just `g_dComIfG_gameInfo`.

I noticed this and fixed the bad logic when I reimplemented it in #167, which worked in most cases. But I accidentally added the addends twice per instruction, which resulted in the addend being double what it should be in some weird rare cases, like the example I'm using for these screenshots.
![image](https://github.com/user-attachments/assets/cd070f39-4f7c-4d74-95f5-a6a2f7717dc9)

After removing the second addition it should really be fixed, both sides resolve to the same addend:
![image](https://github.com/user-attachments/assets/7e4ca6b5-2544-4138-9486-61abe9b4a4f9)
