### PR TITLE
Fix highlighting of signed vs unsigned arguments

### DIFF
--- a/objdiff-core/src/diff/display.rs
+++ b/objdiff-core/src/diff/display.rs
@@ -77,7 +77,7 @@ impl<'a> DiffTextSegment<'a> {
 const EOL_SEGMENT: DiffTextSegment<'static> =
     DiffTextSegment { text: DiffText::Eol, color: DiffTextColor::Normal, pad_to: 0 };
 
-#[derive(Debug, Default, Clone, Eq)]
+#[derive(Debug, Default, Clone)]
 pub enum HighlightKind {
     #[default]
     None,

--- a/objdiff-core/src/diff/display.rs
+++ b/objdiff-core/src/diff/display.rs
@@ -77,7 +77,7 @@ impl<'a> DiffTextSegment<'a> {
 const EOL_SEGMENT: DiffTextSegment<'static> =
     DiffTextSegment { text: DiffText::Eol, color: DiffTextColor::Normal, pad_to: 0 };
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Eq)]
 pub enum HighlightKind {
     #[default]
     None,
@@ -286,6 +286,18 @@ pub fn display_row(
     }
     cb(EOL_SEGMENT)?;
     Ok(())
+}
+
+impl PartialEq<HighlightKind> for HighlightKind {
+    fn eq(&self, other: &HighlightKind) -> bool {
+        match (self, other) {
+            (HighlightKind::Opcode(a), HighlightKind::Opcode(b)) => a == b,
+            (HighlightKind::Argument(a), HighlightKind::Argument(b)) => a.loose_eq(b),
+            (HighlightKind::Symbol(a), HighlightKind::Symbol(b)) => a == b,
+            (HighlightKind::Address(a), HighlightKind::Address(b)) => a == b,
+            _ => false,
+        }
+    }
 }
 
 impl PartialEq<DiffText<'_>> for HighlightKind {


### PR DESCRIPTION
Fixes #193. It seems like objdiff already had code in place to consider unsigned and signed arguments to be the same (`loose_eq`) but that was only being used in `impl PartialEq<DiffText<'_>> for HighlightKind` and not in `impl PartialEq<HighlightKind> for HighlightKind`, so I just copy pasted that and now it works.

![image](https://github.com/user-attachments/assets/c7c09bde-ac35-44f3-8260-75c601d25bb2)
