### PR TITLE
Make `encoding_rs` an optional dependency

### DIFF
--- a/objdiff-core/Cargo.toml
+++ b/objdiff-core/Cargo.toml
@@ -41,6 +41,7 @@ any-arch = [
     "dep:regex",
     "dep:similar",
     "dep:syn",
+    "dep:encoding_rs"
 ]
 bindings = [
     "dep:prost",
@@ -171,7 +172,7 @@ notify-debouncer-full = { version = "0.5.0", optional = true }
 shell-escape = { version = "0.1", optional = true }
 tempfile = { version = "3.19", optional = true }
 time = { version = "0.3", optional = true }
-encoding_rs = "0.8.35"
+encoding_rs = { version = "0.8.35", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", optional = true }


### PR DESCRIPTION
This reduces a bit the dependencies for consumers that won't use the diffing capabilities, like crate consumers using the `bindings` feature only