### PR TITLE
Use symbol name when comparing against an externed reloc

### DIFF
--- a/objdiff-core/src/diff/code.rs
+++ b/objdiff-core/src/diff/code.rs
@@ -325,7 +325,7 @@ fn reloc_eq(
                     || display_ins_data_literals(left_obj, left_ins)
                         == display_ins_data_literals(right_obj, right_ins))
         }
-        (Some(_), None) => false,
+        (Some(_), None) => symbol_name_addend_matches,
         (None, Some(_)) => {
             // Match if possibly stripped weak symbol
             symbol_name_addend_matches && right_reloc.symbol.flags.contains(SymbolFlag::Weak)

--- a/objdiff-core/src/diff/code.rs
+++ b/objdiff-core/src/diff/code.rs
@@ -325,12 +325,11 @@ fn reloc_eq(
                     || display_ins_data_literals(left_obj, left_ins)
                         == display_ins_data_literals(right_obj, right_ins))
         }
-        (Some(_), None) => symbol_name_addend_matches,
         (None, Some(_)) => {
             // Match if possibly stripped weak symbol
             symbol_name_addend_matches && right_reloc.symbol.flags.contains(SymbolFlag::Weak)
         }
-        (None, None) => symbol_name_addend_matches,
+        (Some(_), None) | (None, None) => symbol_name_addend_matches,
     }
 }
 

--- a/objdiff-core/src/diff/data.rs
+++ b/objdiff-core/src/diff/data.rs
@@ -53,12 +53,11 @@ fn reloc_eq(
             section_name_eq(left_obj, right_obj, sl, sr)
                 && (symbol_name_addend_matches || address_eq(left, right))
         }
-        (Some(_), None) => false,
         (None, Some(_)) => {
             // Match if possibly stripped weak symbol
             symbol_name_addend_matches && right.symbol.flags.contains(SymbolFlag::Weak)
         }
-        (None, None) => symbol_name_addend_matches,
+        (Some(_), None) | (None, None) => symbol_name_addend_matches,
     }
 }
 


### PR DESCRIPTION
For partial matching files, often a symbol is externed even though it should exist in the target object. We can still compare the symbol name, instead of always returning a mismatch.

I think this also fixes https://github.com/encounter/objdiff/issues/210