### PR TITLE
PPC pooled relocations: Ignore hidden symbols

### DIFF
--- a/objdiff-core/src/arch/ppc/mod.rs
+++ b/objdiff-core/src/arch/ppc/mod.rs
@@ -635,6 +635,7 @@ fn make_fake_pool_reloc(
         target_symbol = symbols.iter().position(|s| {
             s.section == Some(section_index)
                 && s.size > 0
+                && !s.flags.contains(SymbolFlag::Hidden)
                 && (s.address..s.address + s.size).contains(&target_address)
         })?;
         addend = target_address.checked_sub(symbols[target_symbol].address)? as i64;


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/623dca2f-909e-4e84-986f-3e21ae099d29)
After
![image](https://github.com/user-attachments/assets/7e66f635-74f8-4b2b-8745-cc5af4d923a3)
