### PR TITLE
Ignore switchD_ labels generated by Ghidra

### DIFF
--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -130,7 +130,7 @@ fn map_symbols(
 /// When inferring a symbol's size, we ignore symbols that start with specific prefixes. They are
 /// usually emitted as branch targets and do not represent the start of a function or object.
 fn is_local_label(symbol: &Symbol) -> bool {
-    const LABEL_PREFIXES: &[&str] = &[".L", "LAB_"];
+    const LABEL_PREFIXES: &[&str] = &[".L", "LAB_", "switchD_"];
     symbol.size == 0
         && symbol.flags.contains(SymbolFlag::Local)
         && LABEL_PREFIXES.iter().any(|p| symbol.name.starts_with(p))


### PR DESCRIPTION
Seeing how commonly used boricj's delinker extension is, it makes sense for this one to be included by default, before #238 is considered and worked on.