### PR TITLE
Hide certain symbols for X360 COFFs

### DIFF
--- a/objdiff-core/src/arch/ppc/mod.rs
+++ b/objdiff-core/src/arch/ppc/mod.rs
@@ -366,12 +366,18 @@ impl Arch for ArchPpc {
                     if name.starts_with("except_data_"){
                         SymbolFlag::Hidden.into()
                     }
+                    // if the symbol name starts with __unwind and 
+                    // TODO: a "show unwinds" modifier is unchecked,
+                    // hide the symbol
+                    else if name.starts_with("__unwind"){
+                        SymbolFlag::Hidden.into()
+                    }
                     else {
                         SymbolFlag::none()
                     }
                 }
                 Err(_) => { SymbolFlag::none() }
-            } 
+            }
         }
         else if self.extab.as_ref().is_some_and(|extab| extab.contains_key(&(symbol.index().0 - 1))) {
             SymbolFlag::HasExtra.into()

--- a/objdiff-core/src/arch/ppc/mod.rs
+++ b/objdiff-core/src/arch/ppc/mod.rs
@@ -358,28 +358,7 @@ impl Arch for ArchPpc {
     }
 
     fn extra_symbol_flags(&self, symbol: &object::Symbol) -> SymbolFlagSet {
-        // X360 COFFs should automatically hide all symbols starting with "except_data",
-        // because those are not functions - they're pointers to exception data structs
-        if self.extensions.eq(&powerpc::Extensions::xenon()) {
-            match symbol.name() {
-                Ok(name) => {
-                    if name.starts_with("except_data_"){
-                        SymbolFlag::Hidden.into()
-                    }
-                    // if the symbol name starts with __unwind and 
-                    // TODO: a "show unwinds" modifier is unchecked,
-                    // hide the symbol
-                    else if name.starts_with("__unwind"){
-                        SymbolFlag::Hidden.into()
-                    }
-                    else {
-                        SymbolFlag::none()
-                    }
-                }
-                Err(_) => { SymbolFlag::none() }
-            }
-        }
-        else if self.extab.as_ref().is_some_and(|extab| extab.contains_key(&(symbol.index().0 - 1))) {
+        if self.extab.as_ref().is_some_and(|extab| extab.contains_key(&(symbol.index().0 - 1))) {
             SymbolFlag::HasExtra.into()
         } else {
             SymbolFlag::none()

--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -74,15 +74,13 @@ fn map_symbol(
     {
         flags |= SymbolFlag::Hidden;
     }
-    if file.format() == object::BinaryFormat::Coff {
-        if let Ok(name) = symbol.name() {
-            if name.starts_with("except_data_")
-                || name.starts_with("__unwind")
-                || name.starts_with("__catch")
-            {
-                flags |= SymbolFlag::Hidden;
-            }
-        }
+    if file.format() == object::BinaryFormat::Coff
+        && let Ok(name) = symbol.name()
+        && (name.starts_with("except_data_")
+            || name.starts_with("__unwind")
+            || name.starts_with("__catch"))
+    {
+        flags |= SymbolFlag::Hidden;
     }
 
     let kind = match symbol.kind() {

--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -74,11 +74,13 @@ fn map_symbol(
     {
         flags |= SymbolFlag::Hidden;
     }
-    if file.format() == object::BinaryFormat::Coff
-    {
-        match symbol.name(){
+    if file.format() == object::BinaryFormat::Coff {
+        match symbol.name() {
             Ok(name) => {
-                if name.starts_with("except_data_") || name.starts_with("__unwind") || name.starts_with("__catch") {
+                if name.starts_with("except_data_")
+                    || name.starts_with("__unwind")
+                    || name.starts_with("__catch")
+                {
                     flags |= SymbolFlag::Hidden;
                 }
             }

--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -75,16 +75,13 @@ fn map_symbol(
         flags |= SymbolFlag::Hidden;
     }
     if file.format() == object::BinaryFormat::Coff {
-        match symbol.name() {
-            Ok(name) => {
-                if name.starts_with("except_data_")
-                    || name.starts_with("__unwind")
-                    || name.starts_with("__catch")
-                {
-                    flags |= SymbolFlag::Hidden;
-                }
+        if let Ok(name) = symbol.name() {
+            if name.starts_with("except_data_")
+                || name.starts_with("__unwind")
+                || name.starts_with("__catch")
+            {
+                flags |= SymbolFlag::Hidden;
             }
-            Err(_) => {}
         }
     }
 

--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -74,6 +74,17 @@ fn map_symbol(
     {
         flags |= SymbolFlag::Hidden;
     }
+    if file.format() == object::BinaryFormat::Coff
+    {
+        match symbol.name(){
+            Ok(name) => {
+                if name.starts_with("except_data_") || name.starts_with("__unwind") || name.starts_with("__catch") {
+                    flags |= SymbolFlag::Hidden;
+                }
+            }
+            Err(_) => {}
+        }
+    }
 
     let kind = match symbol.kind() {
         object::SymbolKind::Text => SymbolKind::Function,


### PR DESCRIPTION
This hides any symbol starting with `except_data_` automatically if you're working on X360.
In addition, `__unwind`s are now hidden by default, with the option to show them again added in Arch Settings.

fixes #232 