### PR TITLE
[MIPS]

### DIFF
--- a/objdiff-cli/src/cmd/report.rs
+++ b/objdiff-cli/src/cmd/report.rs
@@ -4,12 +4,10 @@ use anyhow::{Context, Result, bail};
 use argp::FromArgs;
 use objdiff_core::{
     bindings::report::{
-        ChangeItem, ChangeItemInfo, ChangeUnit, Changes, ChangesInput, Measures, REPORT_VERSION,
-        Report, ReportCategory, ReportItem, ReportItemMetadata, ReportUnit, ReportUnitMetadata,
+        ChangeItem, ChangeItemInfo, ChangeUnit, Changes, ChangesInput, Measures, Report, ReportCategory, ReportItem, ReportItemMetadata, ReportUnit, ReportUnitMetadata, REPORT_VERSION
     },
     config::path::platform_path,
-    diff, obj,
-    obj::{SectionKind, SymbolFlag},
+    diff, obj::{self, DiffSide, SectionKind, SymbolFlag},
 };
 use prost::Message;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
@@ -177,14 +175,14 @@ fn report_object(
         .target_path
         .as_ref()
         .map(|p| {
-            obj::read::read(p.as_ref(), diff_config).with_context(|| format!("Failed to open {p}"))
+            obj::read::read(p.as_ref(), diff_config, DiffSide::Target).with_context(|| format!("Failed to open {p}"))
         })
         .transpose()?;
     let base = object
         .base_path
         .as_ref()
         .map(|p| {
-            obj::read::read(p.as_ref(), diff_config).with_context(|| format!("Failed to open {p}"))
+            obj::read::read(p.as_ref(), diff_config, DiffSide::Base).with_context(|| format!("Failed to open {p}"))
         })
         .transpose()?;
     let result =

--- a/objdiff-cli/src/cmd/report.rs
+++ b/objdiff-cli/src/cmd/report.rs
@@ -4,10 +4,12 @@ use anyhow::{Context, Result, bail};
 use argp::FromArgs;
 use objdiff_core::{
     bindings::report::{
-        ChangeItem, ChangeItemInfo, ChangeUnit, Changes, ChangesInput, Measures, Report, ReportCategory, ReportItem, ReportItemMetadata, ReportUnit, ReportUnitMetadata, REPORT_VERSION
+        ChangeItem, ChangeItemInfo, ChangeUnit, Changes, ChangesInput, Measures, REPORT_VERSION,
+        Report, ReportCategory, ReportItem, ReportItemMetadata, ReportUnit, ReportUnitMetadata,
     },
     config::path::platform_path,
-    diff, obj::{self, DiffSide, SectionKind, SymbolFlag},
+    diff,
+    obj::{self, DiffSide, SectionKind, SymbolFlag},
 };
 use prost::Message;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
@@ -175,14 +177,16 @@ fn report_object(
         .target_path
         .as_ref()
         .map(|p| {
-            obj::read::read(p.as_ref(), diff_config, DiffSide::Target).with_context(|| format!("Failed to open {p}"))
+            obj::read::read(p.as_ref(), diff_config, DiffSide::Target)
+                .with_context(|| format!("Failed to open {p}"))
         })
         .transpose()?;
     let base = object
         .base_path
         .as_ref()
         .map(|p| {
-            obj::read::read(p.as_ref(), diff_config, DiffSide::Base).with_context(|| format!("Failed to open {p}"))
+            obj::read::read(p.as_ref(), diff_config, DiffSide::Base)
+                .with_context(|| format!("Failed to open {p}"))
         })
         .transpose()?;
     let result =

--- a/objdiff-core/src/arch/mips.rs
+++ b/objdiff-core/src/arch/mips.rs
@@ -12,9 +12,10 @@ use rabbitizer::{
 
 use crate::{
     arch::{Arch, RelocationOverride, RelocationOverrideTarget},
-    diff::{display::InstructionPart, DiffObjConfig, MipsAbi, MipsInstrCategory},
+    diff::{DiffObjConfig, MipsAbi, MipsInstrCategory, display::InstructionPart},
     obj::{
-        DiffSide, InstructionArg, InstructionArgValue, InstructionRef, Relocation, RelocationFlags, ResolvedInstructionRef, ResolvedRelocation, Section, Symbol, SymbolFlag, SymbolFlagSet
+        DiffSide, InstructionArg, InstructionArgValue, InstructionRef, Relocation, RelocationFlags,
+        ResolvedInstructionRef, ResolvedRelocation, Section, Symbol, SymbolFlag, SymbolFlagSet,
     },
 };
 
@@ -124,7 +125,9 @@ impl ArchMips {
             let Ok(name) = obj_symbol.name() else { continue };
             if let Some(prefix) = name.strip_suffix(".NON_MATCHING") {
                 ignored_symbols.insert(obj_symbol.index().0);
-                if diff_side == DiffSide::Base && let Some(target_symbol) = object.symbol_by_name(prefix) {
+                if diff_side == DiffSide::Base
+                    && let Some(target_symbol) = object.symbol_by_name(prefix)
+                {
                     ignored_symbols.insert(target_symbol.index().0);
                 }
             }

--- a/objdiff-core/src/arch/mips.rs
+++ b/objdiff-core/src/arch/mips.rs
@@ -125,6 +125,8 @@ impl ArchMips {
             let Ok(name) = obj_symbol.name() else { continue };
             if let Some(prefix) = name.strip_suffix(".NON_MATCHING") {
                 ignored_symbols.insert(obj_symbol.index().0);
+                // Only remove the prefixless symbols if we are on the Base side of the diff,
+                // to allow diffing against target objects that contain `.NON_MATCHING` markers.
                 if diff_side == DiffSide::Base
                     && let Some(target_symbol) = object.symbol_by_name(prefix)
                 {

--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -17,13 +17,10 @@ use object::Endian as _;
 
 use crate::{
     diff::{
-        DiffObjConfig,
-        display::{ContextItem, HoverItem, InstructionPart},
+        display::{ContextItem, HoverItem, InstructionPart}, DiffObjConfig
     },
     obj::{
-        FlowAnalysisResult, InstructionArg, InstructionRef, Object, ParsedInstruction, Relocation,
-        RelocationFlags, ResolvedInstructionRef, ResolvedSymbol, Section, Symbol, SymbolFlagSet,
-        SymbolKind,
+        DiffSide, FlowAnalysisResult, InstructionArg, InstructionRef, Object, ParsedInstruction, Relocation, RelocationFlags, ResolvedInstructionRef, ResolvedSymbol, Section, Symbol, SymbolFlagSet, SymbolKind
     },
     util::ReallySigned,
 };
@@ -418,15 +415,18 @@ pub trait Arch: Any + Debug + Send + Sync {
     }
 }
 
-pub fn new_arch(object: &object::File) -> Result<Box<dyn Arch>> {
+pub fn new_arch(object: &object::File, diff_side: DiffSide) -> Result<Box<dyn Arch>> {
     use object::Object as _;
+    // Avoid unused warnings on non-mips builds
+    let _ = diff_side;
+
     Ok(match object.architecture() {
         #[cfg(feature = "ppc")]
         object::Architecture::PowerPc | object::Architecture::PowerPc64 => {
             Box::new(ppc::ArchPpc::new(object)?)
         }
         #[cfg(feature = "mips")]
-        object::Architecture::Mips => Box::new(mips::ArchMips::new(object)?),
+        object::Architecture::Mips => Box::new(mips::ArchMips::new(object, diff_side)?),
         #[cfg(feature = "x86")]
         object::Architecture::I386 | object::Architecture::X86_64 => {
             Box::new(x86::ArchX86::new(object)?)

--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -17,10 +17,13 @@ use object::Endian as _;
 
 use crate::{
     diff::{
-        display::{ContextItem, HoverItem, InstructionPart}, DiffObjConfig
+        DiffObjConfig,
+        display::{ContextItem, HoverItem, InstructionPart},
     },
     obj::{
-        DiffSide, FlowAnalysisResult, InstructionArg, InstructionRef, Object, ParsedInstruction, Relocation, RelocationFlags, ResolvedInstructionRef, ResolvedSymbol, Section, Symbol, SymbolFlagSet, SymbolKind
+        DiffSide, FlowAnalysisResult, InstructionArg, InstructionRef, Object, ParsedInstruction,
+        Relocation, RelocationFlags, ResolvedInstructionRef, ResolvedSymbol, Section, Symbol,
+        SymbolFlagSet, SymbolKind,
     },
     util::ReallySigned,
 };

--- a/objdiff-core/src/jobs/objdiff.rs
+++ b/objdiff-core/src/jobs/objdiff.rs
@@ -5,10 +5,10 @@ use time::OffsetDateTime;
 use typed_path::Utf8PlatformPathBuf;
 
 use crate::{
-    build::{run_make, BuildConfig, BuildStatus},
-    diff::{diff_objs, DiffObjConfig, MappingConfig, ObjectDiff},
-    jobs::{start_job, update_status, Job, JobContext, JobResult, JobState},
-    obj::{read, DiffSide, Object},
+    build::{BuildConfig, BuildStatus, run_make},
+    diff::{DiffObjConfig, MappingConfig, ObjectDiff, diff_objs},
+    jobs::{Job, JobContext, JobResult, JobState, start_job, update_status},
+    obj::{DiffSide, Object, read},
 };
 
 pub struct ObjDiffConfig {

--- a/objdiff-core/src/jobs/objdiff.rs
+++ b/objdiff-core/src/jobs/objdiff.rs
@@ -5,10 +5,10 @@ use time::OffsetDateTime;
 use typed_path::Utf8PlatformPathBuf;
 
 use crate::{
-    build::{BuildConfig, BuildStatus, run_make},
-    diff::{DiffObjConfig, MappingConfig, ObjectDiff, diff_objs},
-    jobs::{Job, JobContext, JobResult, JobState, start_job, update_status},
-    obj::{Object, read},
+    build::{run_make, BuildConfig, BuildStatus},
+    diff::{diff_objs, DiffObjConfig, MappingConfig, ObjectDiff},
+    jobs::{start_job, update_status, Job, JobContext, JobResult, JobState},
+    obj::{read, DiffSide, Object},
 };
 
 pub struct ObjDiffConfig {
@@ -117,7 +117,7 @@ fn run_build(
                 &cancel,
             )?;
             step_idx += 1;
-            match read::read(target_path.as_ref(), &config.diff_obj_config) {
+            match read::read(target_path.as_ref(), &config.diff_obj_config, DiffSide::Target) {
                 Ok(obj) => Some(obj),
                 Err(e) => {
                     first_status = BuildStatus {
@@ -141,7 +141,7 @@ fn run_build(
         Some(base_path) if second_status.success => {
             update_status(context, format!("Loading base {base_path}"), step_idx, total, &cancel)?;
             step_idx += 1;
-            match read::read(base_path.as_ref(), &config.diff_obj_config) {
+            match read::read(base_path.as_ref(), &config.diff_obj_config, DiffSide::Base) {
                 Ok(obj) => Some(obj),
                 Err(e) => {
                     second_status = BuildStatus {

--- a/objdiff-core/src/obj/mod.rs
+++ b/objdiff-core/src/obj/mod.rs
@@ -437,3 +437,11 @@ impl Default for ResolvedInstructionRef<'_> {
         }
     }
 }
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DiffSide {
+    /// The target/expected side of the diff.
+    Target,
+    /// The base side of the diff.
+    Base,
+}

--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -11,10 +11,12 @@ use anyhow::{Context, Result, anyhow, bail, ensure};
 use object::{Object as _, ObjectSection as _, ObjectSymbol as _};
 
 use crate::{
-    arch::{new_arch, Arch, RelocationOverride, RelocationOverrideTarget},
+    arch::{Arch, RelocationOverride, RelocationOverrideTarget, new_arch},
     diff::DiffObjConfig,
     obj::{
-        split_meta::{SplitMeta, SPLITMETA_SECTION}, DiffSide, FlowAnalysisResult, Object, Relocation, RelocationFlags, Section, SectionData, SectionFlag, SectionKind, Symbol, SymbolFlag, SymbolKind
+        DiffSide, FlowAnalysisResult, Object, Relocation, RelocationFlags, Section, SectionData,
+        SectionFlag, SectionKind, Symbol, SymbolFlag, SymbolKind,
+        split_meta::{SPLITMETA_SECTION, SplitMeta},
     },
     util::{align_data_slice_to, align_u64_to, read_u16, read_u32},
 };
@@ -923,7 +925,11 @@ fn do_combine_sections(
 }
 
 #[cfg(feature = "std")]
-pub fn read(obj_path: &std::path::Path, config: &DiffObjConfig, diff_side: DiffSide) -> Result<Object> {
+pub fn read(
+    obj_path: &std::path::Path,
+    config: &DiffObjConfig,
+    diff_side: DiffSide,
+) -> Result<Object> {
     let (data, timestamp) = {
         let file = std::fs::File::open(obj_path)?;
         let timestamp = filetime::FileTime::from_last_modification_time(&file.metadata()?);


### PR DESCRIPTION
In a recent splat/spimdisasm release it started to generate `.NON_MATCHING` markers for all the disassembled symbols by default (https://github.com/ethteck/splat/pull/466). Since this is a splat/spimdisasm specific issue, only the MIPS architecture is affected.

This new behavior is producing issues on projects that uses objdiff as a diffing tool or to generate a progress report.
- Diffing: Any symbol with a `.NON_MATCHING` marker on the target side of the diff is completely absent, making impossible to do any diffing.
  - The following decomp.me scratch shows the issue in action, the target side is missing the function (image 1), but the default diffing tab (the one that uses asm-differ) shows no issue (image 2) https://decomp.me/scratch/e71gG
    <img width="1247" height="291" alt="image" src="https://github.com/user-attachments/assets/1881736e-8d62-431a-8f16-185d7e544e11" />
    <img width="1247" height="291" alt="image" src="https://github.com/user-attachments/assets/be9208c4-b637-4fa6-85b6-943323fe065f" />

- Reporting: Since there are no symbols on the target side then everything is considered matched by objdiff.
<img width="874" height="547" alt="image" src="https://github.com/user-attachments/assets/722f77c2-fe01-4860-998d-723af4be849f" />


This PR addresses those issues by conditionally applying the `.NON_MATCHING` filtering on each side of the view.

- Target side: Show all the symbols except the ones with a `.NON_MATCHING` suffix.
- Base side: Ignore all the `.NON_MATCHING` symbols and also ignore the ones with the same name without the suffix

I did a few tests and this approach seems to fix the issues listed above, even when the target object has a corresponding `.NON_MATCHING` marker for every other symbol.
<img width="1042" height="505" alt="image" src="https://github.com/user-attachments/assets/cdc00b45-3b4c-40b6-ba39-f70cb2085bf8" />
<img width="551" height="674" alt="image" src="https://github.com/user-attachments/assets/13dde6c1-b2a3-42a8-8d2f-5250c69c7cd1" />

I implemented this by adding a new enum `DiffSide`, and pass either `DiffSide::Target` or `DiffSide::Base` to `ArchMips` so the arch itself can know what side of the diff it is working with, allowing it to conditionally filter the symbols.
I implemented this only for `ArchMips`, but it should be simple to implement it to other arches if necessary.
