### PR TITLE
Use the Windows API to demangle MSVC symbols on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3507,6 +3507,7 @@ dependencies = [
  "typed-path",
  "unarm",
  "winapi",
+ "windows-sys 0.59.0",
  "yaxpeax-arch",
  "yaxpeax-arm",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3507,7 +3507,7 @@ dependencies = [
  "typed-path",
  "unarm",
  "winapi",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
  "yaxpeax-arch",
  "yaxpeax-arm",
 ]
@@ -6283,6 +6283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6362,6 +6368,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6413,7 +6428,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/objdiff-core/Cargo.toml
+++ b/objdiff-core/Cargo.toml
@@ -162,6 +162,7 @@ rabbitizer = { version = "2.0.0-alpha.4", default-features = false, features = [
 cpp_demangle = { version = "0.4", default-features = false, features = ["alloc"], optional = true }
 iced-x86 = { version = "1.21", default-features = false, features = ["decoder", "intel", "gas", "masm", "nasm", "exhaustive_enums", "no_std"], optional = true }
 msvc-demangler = { version = "0.11", optional = true }
+windows-sys = { version = "0.59", features = ["Win32_System_Diagnostics_Debug"] }
 
 # arm
 unarm = { version = "1.9", optional = true }

--- a/objdiff-core/Cargo.toml
+++ b/objdiff-core/Cargo.toml
@@ -162,7 +162,6 @@ rabbitizer = { version = "2.0.0-alpha.4", default-features = false, features = [
 cpp_demangle = { version = "0.4", default-features = false, features = ["alloc"], optional = true }
 iced-x86 = { version = "1.21", default-features = false, features = ["decoder", "intel", "gas", "masm", "nasm", "exhaustive_enums", "no_std"], optional = true }
 msvc-demangler = { version = "0.11", optional = true }
-windows-sys = { version = "0.59", features = ["Win32_System_Diagnostics_Debug"] }
 
 # arm
 unarm = { version = "1.9", optional = true }
@@ -182,6 +181,7 @@ encoding_rs = { version = "0.8.35", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", optional = true, features = ["winbase"] }
+windows-sys = { version = "0.61", optional = true, features = ["Win32_System_Diagnostics_Debug"] }
 
 # For Linux static binaries, use rustls
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -307,6 +307,7 @@ impl Arch for ArchX86 {
             #[cfg(target_os = "windows")]
             {
                 use std::ffi::{CStr, CString};
+
                 use windows_sys::Win32::System::Diagnostics::Debug::UnDecorateSymbolName;
 
                 let cstr = CString::new(name).ok()?;

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -306,7 +306,7 @@ impl Arch for ArchX86 {
         if name.starts_with('?') {
             #[cfg(target_os = "windows")]
             {
-                use std::ffi::{CString, CStr};
+                use std::ffi::{CStr, CString};
                 use windows_sys::Win32::System::Diagnostics::Debug::UnDecorateSymbolName;
 
                 let cstr = CString::new(name).ok()?;
@@ -320,10 +320,8 @@ impl Arch for ArchX86 {
                         0, // UNDNAME_COMPLETE
                     );
                     if len > 0 {
-                        let result = CStr::from_ptr(buffer.as_ptr() as *const i8)
-                            .to_str()
-                            .ok()?
-                            .to_string();
+                        let result =
+                            CStr::from_ptr(buffer.as_ptr() as *const i8).to_str().ok()?.to_string();
                         return Some(result);
                     }
                 }

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -314,8 +314,8 @@ impl Arch for ArchX86 {
 
                 unsafe {
                     let len = UnDecorateSymbolName(
-                        cstr.as_ptr() as *const u8,
-                        buffer.as_mut_ptr(),
+                        cstr.as_ptr() as windows_sys::core::PCSTR,
+                        buffer.as_mut_ptr() as windows_sys::core::PSTR,
                         buffer.len() as u32,
                         0, // UNDNAME_COMPLETE
                     );


### PR DESCRIPTION
This PR adds support to use the Windows API to demangle MSVC symbols on Windows.
Shouldn't affect other platforms.
Resolves #252 

<img width="1732" height="80" alt="image" src="https://github.com/user-attachments/assets/04daeba9-032b-417b-a307-49ad6c163ffe" />
