### PR TITLE
[MIPS] Add support for the other ABIs supported by rabbitizer

### DIFF
--- a/objdiff-core/config-schema.json
+++ b/objdiff-core/config-schema.json
@@ -159,12 +159,24 @@
           "name": "O32"
         },
         {
+          "value": "o64",
+          "name": "O64"
+        },
+        {
           "value": "n32",
           "name": "N32"
         },
         {
           "value": "n64",
           "name": "N64"
+        },
+        {
+          "value": "eabi32",
+          "name": "eabi32"
+        },
+        {
+          "value": "eabi64",
+          "name": "eabi64"
         }
       ]
     },

--- a/objdiff-core/src/arch/mips.rs
+++ b/objdiff-core/src/arch/mips.rs
@@ -46,8 +46,11 @@ impl ArchMips {
             object::FileFlags::None => {}
             object::FileFlags::Elf { e_flags, .. } => {
                 abi = match e_flags & EF_MIPS_ABI {
-                    elf::EF_MIPS_ABI_O32 | elf::EF_MIPS_ABI_O64 => Abi::O32,
-                    elf::EF_MIPS_ABI_EABI32 | elf::EF_MIPS_ABI_EABI64 => Abi::N32,
+                    elf::EF_MIPS_ABI_O32 => Abi::O32,
+                    elf::EF_MIPS_ABI_O64 if e_flags & elf::EF_MIPS_ABI2 != 0 => Abi::N64,
+                    elf::EF_MIPS_ABI_O64 => Abi::O64,
+                    elf::EF_MIPS_ABI_EABI32 => Abi::EABI32,
+                    elf::EF_MIPS_ABI_EABI64 => Abi::EABI64,
                     _ => {
                         if e_flags & elf::EF_MIPS_ABI2 != 0 {
                             Abi::N32
@@ -170,8 +173,11 @@ impl ArchMips {
         .with_abi(match diff_config.mips_abi {
             MipsAbi::Auto => self.abi,
             MipsAbi::O32 => Abi::O32,
+            MipsAbi::O64 => Abi::O64,
             MipsAbi::N32 => Abi::N32,
             MipsAbi::N64 => Abi::N64,
+            MipsAbi::Eabi32 => Abi::EABI32,
+            MipsAbi::Eabi64 => Abi::EABI64,
         })
     }
 

--- a/objdiff-core/tests/snapshots/arch_mips__read_mips.snap
+++ b/objdiff-core/tests/snapshots/arch_mips__read_mips.snap
@@ -1,12 +1,12 @@
 ---
 source: objdiff-core/tests/arch_mips.rs
-assertion_line: 10
+assertion_line: 12
 expression: obj
 ---
 Object {
     arch: ArchMips {
         endianness: Little,
-        abi: N32,
+        abi: EABI64,
         isa_extension: Some(
             R5900EE,
         ),


### PR DESCRIPTION
Just noted objdiff isn't using all the ABIs supported by rabbitizer.

Hopefully I didn't miss adding the new abis somewhere else

