### PR TITLE
Arch-independent demangling and add `gnuv2_demangle` for old g++ projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,6 +2021,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gnuv2_demangle"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73012a2b235359cdf9e71e153da760f7268a4ad1e2c86fa3a70dca2113015695"
+
+[[package]]
 name = "gpu-alloc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3504,6 +3510,7 @@ dependencies = [
  "flagset",
  "gimli 0.32.0",
  "globset",
+ "gnuv2_demangle",
  "heck",
  "iced-x86",
  "insta",

--- a/objdiff-core/Cargo.toml
+++ b/objdiff-core/Cargo.toml
@@ -41,7 +41,8 @@ any-arch = [
     "dep:regex",
     "dep:similar",
     "dep:syn",
-    "dep:encoding_rs"
+    "dep:encoding_rs",
+    "demangler",
 ]
 bindings = [
     "dep:prost",
@@ -88,39 +89,36 @@ std = [
 ]
 mips = [
     "any-arch",
-    "dep:cpp_demangle",
-    "dep:cwdemangle",
     "dep:rabbitizer",
-    "dep:gnuv2_demangle",
 ]
 ppc = [
     "any-arch",
-    "dep:cwdemangle",
     "dep:cwextab",
     "dep:powerpc",
     "dep:rlwinmdec",
 ]
 x86 = [
     "any-arch",
-    "dep:cpp_demangle",
     "dep:iced-x86",
-    "dep:msvc-demangler",
-    "dep:gnuv2_demangle",
 ]
 arm = [
     "any-arch",
     "dep:arm-attr",
-    "dep:cpp_demangle",
     "dep:unarm",
 ]
 arm64 = [
     "any-arch",
-    "dep:cpp_demangle",
     "dep:yaxpeax-arch",
     "dep:yaxpeax-arm",
 ]
 superh = [
     "any-arch",
+]
+demangler = [
+    "dep:cpp_demangle",
+    "dep:cwdemangle",
+    "dep:gnuv2_demangle",
+    "dep:msvc-demangler",
 ]
 
 [package.metadata.docs.rs]

--- a/objdiff-core/Cargo.toml
+++ b/objdiff-core/Cargo.toml
@@ -91,6 +91,7 @@ mips = [
     "dep:cpp_demangle",
     "dep:cwdemangle",
     "dep:rabbitizer",
+    "dep:gnuv2_demangle",
 ]
 ppc = [
     "any-arch",
@@ -157,6 +158,7 @@ rlwinmdec = { version = "1.1", optional = true }
 
 # mips
 rabbitizer = { version = "2.0.0-alpha.4", default-features = false, features = ["all_extensions"], optional = true }
+gnuv2_demangle ={ version = "0.1.0", optional = true }
 
 # x86
 cpp_demangle = { version = "0.4", default-features = false, features = ["alloc"], optional = true }

--- a/objdiff-core/Cargo.toml
+++ b/objdiff-core/Cargo.toml
@@ -105,6 +105,7 @@ x86 = [
     "dep:cpp_demangle",
     "dep:iced-x86",
     "dep:msvc-demangler",
+    "dep:gnuv2_demangle",
 ]
 arm = [
     "any-arch",

--- a/objdiff-core/Cargo.toml
+++ b/objdiff-core/Cargo.toml
@@ -150,19 +150,15 @@ gimli = { git = "https://github.com/gimli-rs/gimli", rev = "7335f00e7c39fd501511
 typed-arena = { version = "2.0", default-features = false, optional = true }
 
 # ppc
-cwdemangle = { version = "1.0", optional = true }
 cwextab = { version = "1.1", optional = true }
 powerpc = { version = "0.4", optional = true }
 rlwinmdec = { version = "1.1", optional = true }
 
 # mips
 rabbitizer = { version = "2.0.0-alpha.4", default-features = false, features = ["all_extensions"], optional = true }
-gnuv2_demangle ={ version = "0.1.0", optional = true }
 
 # x86
-cpp_demangle = { version = "0.4", default-features = false, features = ["alloc"], optional = true }
 iced-x86 = { version = "1.21", default-features = false, features = ["decoder", "intel", "gas", "masm", "nasm", "exhaustive_enums", "no_std"], optional = true }
-msvc-demangler = { version = "0.11", optional = true }
 
 # arm
 unarm = { version = "1.9", optional = true }
@@ -179,6 +175,12 @@ shell-escape = { version = "0.1", optional = true }
 tempfile = { version = "3.20", optional = true }
 time = { version = "0.3", optional = true }
 encoding_rs = { version = "0.8.35", optional = true }
+
+# demangler
+cpp_demangle = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
+cwdemangle = { version = "1.0", optional = true }
+gnuv2_demangle = { version = "0.1.0", optional = true }
+msvc-demangler = { version = "0.11", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", optional = true, features = ["winbase"] }

--- a/objdiff-core/config-schema.json
+++ b/objdiff-core/config-schema.json
@@ -26,6 +26,37 @@
       ]
     },
     {
+      "id": "demangler",
+      "type": "choice",
+      "default": "auto",
+      "name": "Demangler",
+      "description": "Which demangler should be used to demangle each symbol.",
+      "items": [
+        {
+          "value": "auto",
+          "name": "Auto",
+          "description": "Try to automatically guess the mangling format."
+        },
+        {
+          "value": "codewarrior",
+          "name": "CodeWarrior"
+        },
+        {
+          "value": "msvc",
+          "name": "MSVC"
+        },
+        {
+          "value": "gnu_modern",
+          "name": "GNU g++ (Itanium)"
+        },
+        {
+          "value": "gnu_v2",
+          "name": "GNU g++ (V2)",
+          "description": "Use the old GNU mangling ABI. Used up to g++ 2.9.x"
+        }
+      ]
+    },
+    {
       "id": "analyzeDataFlow",
       "type": "boolean",
       "default": false,
@@ -259,6 +290,7 @@
       "name": "General",
       "properties": [
         "functionRelocDiffs",
+        "demangler",
         "spaceBetweenArgs",
         "combineDataSections",
         "combineTextSections"

--- a/objdiff-core/config-schema.json
+++ b/objdiff-core/config-schema.json
@@ -50,8 +50,8 @@
           "name": "Itanium"
         },
         {
-          "value": "gnu_v2",
-          "name": "GNU g++ (V2)",
+          "value": "gnu_legacy",
+          "name": "GNU g++ (Legacy)",
           "description": "Use the old GNU mangling ABI. Used up to g++ 2.9.x"
         }
       ]

--- a/objdiff-core/config-schema.json
+++ b/objdiff-core/config-schema.json
@@ -46,8 +46,8 @@
           "name": "MSVC"
         },
         {
-          "value": "gnu_modern",
-          "name": "GNU g++ (Itanium)"
+          "value": "itanium",
+          "name": "Itanium"
         },
         {
           "value": "gnu_v2",

--- a/objdiff-core/src/arch/arm.rs
+++ b/objdiff-core/src/arch/arm.rs
@@ -1,9 +1,4 @@
-use alloc::{
-    collections::BTreeMap,
-    format,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{collections::BTreeMap, format, string::ToString, vec::Vec};
 
 use anyhow::{Result, bail};
 use arm_attr::{BuildAttrs, enums::CpuArch, tag::Tag};
@@ -407,12 +402,6 @@ impl Arch for ArchArm {
             }
             _ => Ok(None),
         }
-    }
-
-    fn demangle(&self, name: &str) -> Option<String> {
-        cpp_demangle::Symbol::new(name)
-            .ok()
-            .and_then(|s| s.demangle(&cpp_demangle::DemangleOptions::default()).ok())
     }
 
     fn reloc_name(&self, flags: RelocationFlags) -> Option<&'static str> {

--- a/objdiff-core/src/arch/arm64.rs
+++ b/objdiff-core/src/arch/arm64.rs
@@ -1,8 +1,4 @@
-use alloc::{
-    format,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{format, string::ToString, vec::Vec};
 use core::cmp::Ordering;
 
 use anyhow::Result;
@@ -106,12 +102,6 @@ impl Arch for ArchArm64 {
             cb(arg)?;
         }
         Ok(())
-    }
-
-    fn demangle(&self, name: &str) -> Option<String> {
-        cpp_demangle::Symbol::new(name)
-            .ok()
-            .and_then(|s| s.demangle(&cpp_demangle::DemangleOptions::default()).ok())
     }
 
     fn reloc_name(&self, flags: RelocationFlags) -> Option<&'static str> {

--- a/objdiff-core/src/arch/mips.rs
+++ b/objdiff-core/src/arch/mips.rs
@@ -305,10 +305,14 @@ impl Arch for ArchMips {
     }
 
     fn demangle(&self, name: &str) -> Option<String> {
-        cpp_demangle::Symbol::new(name)
+        gnuv2_demangle::demangle(name, &gnuv2_demangle::DemangleConfig::new_no_cfilt_mimics())
             .ok()
-            .and_then(|s| s.demangle(&cpp_demangle::DemangleOptions::default()).ok())
-            .or_else(|| cwdemangle::demangle(name, &cwdemangle::DemangleOptions::default()))
+            .or_else(|| {
+                cpp_demangle::Symbol::new(name)
+                    .ok()
+                    .and_then(|s| s.demangle(&cpp_demangle::DemangleOptions::default()).ok())
+                    .or_else(|| cwdemangle::demangle(name, &cwdemangle::DemangleOptions::default()))
+            })
     }
 
     fn reloc_name(&self, flags: RelocationFlags) -> Option<&'static str> {

--- a/objdiff-core/src/arch/mips.rs
+++ b/objdiff-core/src/arch/mips.rs
@@ -1,6 +1,6 @@
 use alloc::{
     collections::{BTreeMap, BTreeSet},
-    string::{String, ToString},
+    string::ToString,
     vec::Vec,
 };
 
@@ -302,17 +302,6 @@ impl Arch for ArchMips {
             }
             _ => Ok(None),
         }
-    }
-
-    fn demangle(&self, name: &str) -> Option<String> {
-        gnuv2_demangle::demangle(name, &gnuv2_demangle::DemangleConfig::new_no_cfilt_mimics())
-            .ok()
-            .or_else(|| {
-                cpp_demangle::Symbol::new(name)
-                    .ok()
-                    .and_then(|s| s.demangle(&cpp_demangle::DemangleOptions::default()).ok())
-                    .or_else(|| cwdemangle::demangle(name, &cwdemangle::DemangleOptions::default()))
-            })
     }
 
     fn reloc_name(&self, flags: RelocationFlags) -> Option<&'static str> {

--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -371,8 +371,6 @@ pub trait Arch: Any + Debug + Send + Sync {
         Ok(None)
     }
 
-    fn demangle(&self, _name: &str) -> Option<String> { None }
-
     fn reloc_name(&self, _flags: RelocationFlags) -> Option<&'static str> { None }
 
     fn data_reloc_size(&self, flags: RelocationFlags) -> usize;

--- a/objdiff-core/src/arch/ppc/mod.rs
+++ b/objdiff-core/src/arch/ppc/mod.rs
@@ -308,18 +308,6 @@ impl Arch for ArchPpc {
         }
     }
 
-    fn demangle(&self, mut name: &str) -> Option<String> {
-        if name.starts_with('?') {
-            msvc_demangler::demangle(name, msvc_demangler::DemangleFlags::llvm()).ok()
-        } else {
-            name = name.trim_start_matches('.');
-            cpp_demangle::Symbol::new(name)
-                .ok()
-                .and_then(|s| s.demangle(&cpp_demangle::DemangleOptions::default()).ok())
-                .or_else(|| cwdemangle::demangle(name, &cwdemangle::DemangleOptions::default()))
-        }
-    }
-
     fn reloc_name(&self, flags: RelocationFlags) -> Option<&'static str> {
         match flags {
             RelocationFlags::Elf(r_type) => match r_type {

--- a/objdiff-core/src/arch/superh/mod.rs
+++ b/objdiff-core/src/arch/superh/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::BTreeMap, format, string::String, vec, vec::Vec};
+use alloc::{collections::BTreeMap, format, vec::Vec};
 
 use anyhow::Result;
 use object::elf;
@@ -130,12 +130,6 @@ impl Arch for ArchSuperH {
         }
 
         Ok(())
-    }
-
-    fn demangle(&self, name: &str) -> Option<String> {
-        cpp_demangle::Symbol::new(name)
-            .ok()
-            .and_then(|s| s.demangle(&cpp_demangle::DemangleOptions::default()).ok())
     }
 
     fn reloc_name(&self, flags: RelocationFlags) -> Option<&'static str> {

--- a/objdiff-core/src/arch/superh/mod.rs
+++ b/objdiff-core/src/arch/superh/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::BTreeMap, format, vec::Vec};
+use alloc::{collections::BTreeMap, format, vec, vec::Vec};
 
 use anyhow::Result;
 use object::elf;

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -307,6 +307,13 @@ impl Arch for ArchX86 {
             cpp_demangle::Symbol::new(name)
                 .ok()
                 .and_then(|s| s.demangle(&cpp_demangle::DemangleOptions::default()).ok())
+                .or_else(|| {
+                    gnuv2_demangle::demangle(
+                        name,
+                        &gnuv2_demangle::DemangleConfig::new_no_cfilt_mimics(),
+                    )
+                    .ok()
+                })
         }
     }
 

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, format, string::String, vec::Vec};
+use alloc::{boxed::Box, format, vec::Vec};
 use core::cmp::Ordering;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -298,23 +298,6 @@ impl Arch for ArchX86 {
             },
         };
         Ok(Some(RelocationOverride { target: RelocationOverrideTarget::Keep, addend }))
-    }
-
-    fn demangle(&self, name: &str) -> Option<String> {
-        if name.starts_with('?') {
-            msvc_demangler::demangle(name, msvc_demangler::DemangleFlags::llvm()).ok()
-        } else {
-            cpp_demangle::Symbol::new(name)
-                .ok()
-                .and_then(|s| s.demangle(&cpp_demangle::DemangleOptions::default()).ok())
-                .or_else(|| {
-                    gnuv2_demangle::demangle(
-                        name,
-                        &gnuv2_demangle::DemangleConfig::new_no_cfilt_mimics(),
-                    )
-                    .ok()
-                })
-        }
     }
 
     fn reloc_name(&self, flags: RelocationFlags) -> Option<&'static str> {

--- a/objdiff-core/src/diff/demangler.rs
+++ b/objdiff-core/src/diff/demangler.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 use crate::diff::Demangler;
 
 #[cfg(feature = "demangler")]

--- a/objdiff-core/src/diff/demangler.rs
+++ b/objdiff-core/src/diff/demangler.rs
@@ -9,14 +9,14 @@ impl Demangler {
             Demangler::Codewarrior => Self::demangle_codewarrior(name),
             Demangler::Msvc => Self::demangle_msvc(name),
             Demangler::Itanium => Self::demangle_itanium(name),
-            Demangler::GnuV2 => Self::demangle_gnu_v2(name),
+            Demangler::GnuLegacy => Self::demangle_gnu_legacy(name),
             Demangler::Auto => {
                 // Try to guess
                 if name.starts_with('?') {
                     Self::demangle_msvc(name)
                 } else {
                     Self::demangle_codewarrior(name)
-                        .or_else(|| Self::demangle_gnu_v2(name))
+                        .or_else(|| Self::demangle_gnu_legacy(name))
                         .or_else(|| Self::demangle_itanium(name))
                 }
             }
@@ -32,12 +32,14 @@ impl Demangler {
     }
 
     fn demangle_itanium(name: &str) -> Option<String> {
+        let name = name.trim_start_matches('.');
         cpp_demangle::Symbol::new(name)
             .ok()
             .and_then(|s| s.demangle(&cpp_demangle::DemangleOptions::default()).ok())
     }
 
-    fn demangle_gnu_v2(name: &str) -> Option<String> {
+    fn demangle_gnu_legacy(name: &str) -> Option<String> {
+        let name = name.trim_start_matches('.');
         gnuv2_demangle::demangle(name, &gnuv2_demangle::DemangleConfig::new_no_cfilt_mimics()).ok()
     }
 }

--- a/objdiff-core/src/diff/demangler.rs
+++ b/objdiff-core/src/diff/demangler.rs
@@ -1,0 +1,46 @@
+use crate::diff::Demangler;
+
+#[cfg(feature = "demangler")]
+impl Demangler {
+    pub fn demangle(&self, name: &str) -> Option<String> {
+        match self {
+            Demangler::Codewarrior => Self::demangle_codewarrior(name),
+            Demangler::Msvc => Self::demangle_msvc(name),
+            Demangler::GnuModern => Self::demangle_gnu_modern(name),
+            Demangler::GnuV2 => Self::demangle_gnu_v2(name),
+            Demangler::Auto => {
+                // Try to guess
+                if name.starts_with('?') {
+                    Self::demangle_msvc(name)
+                } else {
+                    Self::demangle_codewarrior(name)
+                        .or_else(|| Self::demangle_gnu_v2(name))
+                        .or_else(|| Self::demangle_gnu_modern(name))
+                }
+            }
+        }
+    }
+
+    fn demangle_codewarrior(name: &str) -> Option<String> {
+        cwdemangle::demangle(name, &cwdemangle::DemangleOptions::default())
+    }
+
+    fn demangle_msvc(name: &str) -> Option<String> {
+        msvc_demangler::demangle(name, msvc_demangler::DemangleFlags::llvm()).ok()
+    }
+
+    fn demangle_gnu_modern(name: &str) -> Option<String> {
+        cpp_demangle::Symbol::new(name)
+            .ok()
+            .and_then(|s| s.demangle(&cpp_demangle::DemangleOptions::default()).ok())
+    }
+
+    fn demangle_gnu_v2(name: &str) -> Option<String> {
+        gnuv2_demangle::demangle(name, &gnuv2_demangle::DemangleConfig::new_no_cfilt_mimics()).ok()
+    }
+}
+
+#[cfg(not(feature = "demangler"))]
+impl Demangler {
+    pub fn demangle(&self, _name: &str) -> Option<String> { None }
+}

--- a/objdiff-core/src/diff/demangler.rs
+++ b/objdiff-core/src/diff/demangler.rs
@@ -8,7 +8,7 @@ impl Demangler {
         match self {
             Demangler::Codewarrior => Self::demangle_codewarrior(name),
             Demangler::Msvc => Self::demangle_msvc(name),
-            Demangler::GnuModern => Self::demangle_gnu_modern(name),
+            Demangler::Itanium => Self::demangle_itanium(name),
             Demangler::GnuV2 => Self::demangle_gnu_v2(name),
             Demangler::Auto => {
                 // Try to guess
@@ -17,7 +17,7 @@ impl Demangler {
                 } else {
                     Self::demangle_codewarrior(name)
                         .or_else(|| Self::demangle_gnu_v2(name))
-                        .or_else(|| Self::demangle_gnu_modern(name))
+                        .or_else(|| Self::demangle_itanium(name))
                 }
             }
         }
@@ -31,7 +31,7 @@ impl Demangler {
         msvc_demangler::demangle(name, msvc_demangler::DemangleFlags::llvm()).ok()
     }
 
-    fn demangle_gnu_modern(name: &str) -> Option<String> {
+    fn demangle_itanium(name: &str) -> Option<String> {
         cpp_demangle::Symbol::new(name)
             .ok()
             .and_then(|s| s.demangle(&cpp_demangle::DemangleOptions::default()).ok())

--- a/objdiff-core/src/diff/mod.rs
+++ b/objdiff-core/src/diff/mod.rs
@@ -22,6 +22,7 @@ use crate::{
 
 pub mod code;
 pub mod data;
+pub mod demangler;
 pub mod display;
 
 include!(concat!(env!("OUT_DIR"), "/config.gen.rs"));

--- a/objdiff-gui/src/app.rs
+++ b/objdiff-gui/src/app.rs
@@ -811,9 +811,7 @@ impl eframe::App for App {
 
         project_window(ctx, state, show_project_config, config_state, appearance);
         appearance_window(ctx, show_appearance_config, appearance);
-        let demangler =
-            state.read().map(|state| state.config.diff_obj_config.demangler).unwrap_or_default();
-        demangle_window(ctx, show_demangle, demangle_state, appearance, demangler);
+        demangle_window(ctx, show_demangle, demangle_state, appearance);
         rlwinm_decode_window(ctx, show_rlwinm_decode, rlwinm_decode_state, appearance);
         arch_config_window(ctx, state, show_arch_config, appearance);
         debug_window(ctx, show_debug, frame_history, appearance);

--- a/objdiff-gui/src/app.rs
+++ b/objdiff-gui/src/app.rs
@@ -20,7 +20,7 @@ use objdiff_core::{
         default_ignore_patterns, default_watch_patterns, path::platform_path_serde_option,
         save_project_config,
     },
-    diff::DiffObjConfig,
+    diff::{Demangler, DiffObjConfig},
     jobs::{Job, JobQueue, JobResult},
 };
 use time::UtcOffset;
@@ -811,7 +811,9 @@ impl eframe::App for App {
 
         project_window(ctx, state, show_project_config, config_state, appearance);
         appearance_window(ctx, show_appearance_config, appearance);
-        demangle_window(ctx, show_demangle, demangle_state, appearance);
+        let demangler =
+            state.read().map(|state| state.config.diff_obj_config.demangler).unwrap_or_default();
+        demangle_window(ctx, show_demangle, demangle_state, appearance, demangler);
         rlwinm_decode_window(ctx, show_rlwinm_decode, rlwinm_decode_state, appearance);
         arch_config_window(ctx, state, show_arch_config, appearance);
         debug_window(ctx, show_debug, frame_history, appearance);

--- a/objdiff-gui/src/app.rs
+++ b/objdiff-gui/src/app.rs
@@ -20,7 +20,7 @@ use objdiff_core::{
         default_ignore_patterns, default_watch_patterns, path::platform_path_serde_option,
         save_project_config,
     },
-    diff::{Demangler, DiffObjConfig},
+    diff::DiffObjConfig,
     jobs::{Job, JobQueue, JobResult},
 };
 use time::UtcOffset;

--- a/objdiff-gui/src/views/demangle.rs
+++ b/objdiff-gui/src/views/demangle.rs
@@ -1,11 +1,12 @@
 use egui::TextStyle;
-use objdiff_core::diff::Demangler;
+use objdiff_core::diff::{ConfigEnum, Demangler};
 
 use crate::views::appearance::Appearance;
 
 #[derive(Default)]
 pub struct DemangleViewState {
     pub text: String,
+    pub demangler: Demangler,
 }
 
 pub fn demangle_window(
@@ -13,12 +14,19 @@ pub fn demangle_window(
     show: &mut bool,
     state: &mut DemangleViewState,
     appearance: &Appearance,
-    demangler: Demangler,
 ) {
     egui::Window::new("Demangle").open(show).show(ctx, |ui| {
+        egui::ComboBox::from_label("Demangler")
+            .selected_text(state.demangler.name().to_string())
+            .show_ui(ui, |ui| {
+                for demangler in Demangler::variants() {
+                    ui.selectable_value(&mut state.demangler, *demangler, demangler.name());
+                }
+            });
+        ui.separator();
         ui.text_edit_singleline(&mut state.text);
         ui.add_space(10.0);
-        if let Some(demangled) = demangler.demangle(&state.text) {
+        if let Some(demangled) = state.demangler.demangle(&state.text) {
             ui.scope(|ui| {
                 ui.style_mut().override_text_style = Some(TextStyle::Monospace);
                 ui.colored_label(appearance.replace_color, &demangled);

--- a/objdiff-gui/src/views/demangle.rs
+++ b/objdiff-gui/src/views/demangle.rs
@@ -1,4 +1,5 @@
 use egui::TextStyle;
+use objdiff_core::diff::Demangler;
 
 use crate::views::appearance::Appearance;
 
@@ -12,11 +13,12 @@ pub fn demangle_window(
     show: &mut bool,
     state: &mut DemangleViewState,
     appearance: &Appearance,
+    demangler: Demangler,
 ) {
     egui::Window::new("Demangle").open(show).show(ctx, |ui| {
         ui.text_edit_singleline(&mut state.text);
         ui.add_space(10.0);
-        if let Some(demangled) = cwdemangle::demangle(&state.text, &Default::default()) {
+        if let Some(demangled) = demangler.demangle(&state.text) {
             ui.scope(|ui| {
                 ui.style_mut().override_text_style = Some(TextStyle::Monospace);
                 ui.colored_label(appearance.replace_color, &demangled);


### PR DESCRIPTION
I tested it locally and works fine.

I'm unsure about a few things.
- I only added this new demangler to mips and x86, should I add it to any other arch?
- Should `cpp_demangle` be removed from mips? I don't know if there's any mips project that uses a new enough g++ compiler that uses the new mangling abi. Or maybe invert `cwdemangle` and `cpp_demangle` since it is more likely for cw to be used in mips than a new g++.