### PR TITLE
Update `gnuv2_demangle`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "gnuv2_demangle"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73012a2b235359cdf9e71e153da760f7268a4ad1e2c86fa3a70dca2113015695"
+checksum = "e7d12082d0c6e6f34b51ee608cc7d882bc993304f2dde3a67cfdc9196ed2741d"
 
 [[package]]
 name = "gpu-alloc"

--- a/objdiff-core/Cargo.toml
+++ b/objdiff-core/Cargo.toml
@@ -179,7 +179,7 @@ encoding_rs = { version = "0.8.35", optional = true }
 # demangler
 cpp_demangle = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 cwdemangle = { version = "1.0", optional = true }
-gnuv2_demangle = { version = "0.1.0", optional = true }
+gnuv2_demangle = { version = "0.3", optional = true }
 msvc-demangler = { version = "0.11", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/objdiff-core/src/diff/demangler.rs
+++ b/objdiff-core/src/diff/demangler.rs
@@ -41,7 +41,7 @@ impl Demangler {
 
     fn demangle_gnu_legacy(name: &str) -> Option<String> {
         let name = name.trim_start_matches('.');
-        gnuv2_demangle::demangle(name, &gnuv2_demangle::DemangleConfig::new_no_cfilt_mimics()).ok()
+        gnuv2_demangle::demangle(name, &gnuv2_demangle::DemangleConfig::new()).ok()
     }
 }
 


### PR DESCRIPTION
Update `gnuv2_demangle` to version 0.3.

- Adds support for various mangling kinds that I haven't had tests before.
- Should properly demangle all overloadable operators now instead of just a subset.
- Support for some mangling variants used by ProDG.
- A bunch of fixes.
- And some other stuff, the full changelog is available [here](https://github.com/Decompollaborate/gnuv2_demangle/blob/main/CHANGELOG.md).