### PR TITLE
Update `gnuv2_demangle` to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "gnuv2_demangle"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d12082d0c6e6f34b51ee608cc7d882bc993304f2dde3a67cfdc9196ed2741d"
+checksum = "3f4eda49d36ceaaaf3af38940a636b0514472cdba8b2158b20b58e91e50df4c7"
 
 [[package]]
 name = "gpu-alloc"

--- a/objdiff-core/Cargo.toml
+++ b/objdiff-core/Cargo.toml
@@ -179,7 +179,7 @@ encoding_rs = { version = "0.8.35", optional = true }
 # demangler
 cpp_demangle = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 cwdemangle = { version = "1.0", optional = true }
-gnuv2_demangle = { version = "0.3", optional = true }
+gnuv2_demangle = { version = "0.4", optional = true }
 msvc-demangler = { version = "0.11", optional = true }
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
Update `gnuv2_demangle` to version 0.4

- Support for function pointers in template lists.
- Support for template specializations inside namespaces.
- Proper support for compilers using `.` as GCC's `CPLUS_MARKER`.
- Among other fixes. Full list is available [here](https://github.com/Decompollaborate/gnuv2_demangle/blob/main/CHANGELOG.md).