### PR TITLE
ARM: Fix .word not on 4-byte boundary

### DIFF
--- a/objdiff-core/src/arch/arm.rs
+++ b/objdiff-core/src/arch/arm.rs
@@ -224,7 +224,10 @@ impl Arch for ArchArm {
             }
 
             // Check how many bytes we can/should read
-            let num_code_bytes = if data.len() >= 4 {
+            let num_code_bytes = if mode == unarm::ParseMode::Data {
+                // 32-bit .word value should be aligned on a 4-byte boundary, otherwise use .hword
+                if address & 3 == 0 { 4 } else { 2 }
+            } else if data.len() >= 4 {
                 // Read 4 bytes even for Thumb, as the parser will determine if it's a 2 or 4 byte instruction
                 4
             } else if mode != unarm::ParseMode::Arm {


### PR DESCRIPTION
Since #274, released in objdiff v3.4.0, `.word` directives could be misaligned and placed on a 2-byte boundary in a Thumb function. This PR fixes that by only allowing `.word` when the address is aligned by 4 and instead using `.hword` if aligned by 2.

Closes #281