### PR TITLE
Ignore hidden symbols when diffing data sections

### DIFF
--- a/objdiff-core/src/diff/data.rs
+++ b/objdiff-core/src/diff/data.rs
@@ -588,6 +588,7 @@ fn symbols_matching_section(
         s.section == Some(section_idx)
             && s.kind != SymbolKind::Section
             && s.size > 0
+            && !s.flags.contains(SymbolFlag::Hidden)
             && !s.flags.contains(SymbolFlag::Ignored)
     })
 }


### PR DESCRIPTION
I noticed that dtk's auto-generated "gap" symbols are hidden in objdiff, but still count against the data section's match percent.

This can be an issue for games like TP which don't have alignment info in their symbol maps, as dtk will add a ton of gap symbols on the left to compensate for the unknown alignment, and then the right side will have the correct alignment so they don't need gap symbols. By ignoring hidden symbols like this, it more accurately looks at the matched data, causing TP's matched data % to increase from its current value of 46.05% (obviously wrong since it's lower than 59.24% linked data) up to 97.02% matched, which I think I probably accurate.

For games with known alignment like TWW, this change seems to have no effect at all. Data diffs are accurate both before and after.

I'm not sure if ignoring gaps was intentional or not. Are there other games where ignoring them results in less accurate diffs?