### PR TITLE
Fix mouse hovers overriding typing in the symbol search field

### DIFF
--- a/objdiff-gui/src/views/symbol_diff.rs
+++ b/objdiff-gui/src/views/symbol_diff.rs
@@ -619,11 +619,20 @@ fn symbol_ui(
             column,
         )));
     } else if response.hovered() {
-        ret = Some(if column == 0 {
-            DiffViewAction::SetSymbolHighlight(Some(symbol_idx), symbol_diff.target_symbol, false)
+        let new_highlighted_symbol = if column == 0 {
+            (Some(symbol_idx), symbol_diff.target_symbol)
         } else {
-            DiffViewAction::SetSymbolHighlight(symbol_diff.target_symbol, Some(symbol_idx), false)
-        });
+            (symbol_diff.target_symbol, Some(symbol_idx))
+        };
+        // Only set the highlight if it changed from the previous frame.
+        // This prevents passive mouse hovers from overriding keyboard actions.
+        if new_highlighted_symbol != state.highlighted_symbol {
+            ret = Some(DiffViewAction::SetSymbolHighlight(
+                new_highlighted_symbol.0,
+                new_highlighted_symbol.1,
+                false,
+            ));
+        }
     }
     ret
 }


### PR DESCRIPTION
This fixes a bug that has existed in the GUI for a while where if your mouse was hovering over a symbol, it would be impossible to type in the symbol filter field, so you basically had to move your mouse outside of the objdiff window any time you wanted to search for a symbol. This is because the mouse hover was sending an action every frame that took priority over the action for updating the filter field. I changed it to only send the hover action when your mouse changes which symbol it's hovering over so that this won't happen as long as your mouse is still.