### PR TITLE
Handle IMAGE_REL_PPC_ADDR32 size in Coff

### DIFF
--- a/objdiff-core/src/arch/ppc/mod.rs
+++ b/objdiff-core/src/arch/ppc/mod.rs
@@ -344,6 +344,9 @@ impl Arch for ArchPpc {
             },
             RelocationFlags::Coff(r_type) => match r_type {
                 pe::IMAGE_REL_PPC_ADDR32 => 4,
+                pe::IMAGE_REL_PPC_REFHI => 2,
+                pe::IMAGE_REL_PPC_REFLO => 2,
+                pe::IMAGE_REL_PPC_REL24 => 3,
                 _ => 1,
             },
         }


### PR DESCRIPTION
COFF IMAGE_REL_PPC_ADDR32 was being handled as 1 byte. ~~There's other relocation flags that should be probably be handled but I'm not sure off the top of my head what they're supposed to be so I'm just PR'ing this.~~

Edit: IMAGE_REL_PPC_REFHI IMAGE_REL_PPC_REFLO IMAGE_REL_PPC_REL24