### PR TITLE
Fix extab hover window display issue

### DIFF
--- a/objdiff-core/src/arch/arm.rs
+++ b/objdiff-core/src/arch/arm.rs
@@ -162,7 +162,7 @@ impl ArchArm {
 }
 
 impl Arch for ArchArm {
-    fn post_init(&mut self, sections: &[Section], symbols: &[Symbol]) {
+    fn post_init(&mut self, sections: &[Section], symbols: &[Symbol], _symbol_indices: &[usize]) {
         self.disasm_modes = Self::get_mapping_symbols(sections, symbols);
     }
 

--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -340,7 +340,8 @@ impl dyn Arch {
 
 pub trait Arch: Any + Debug + Send + Sync {
     /// Finishes arch-specific initialization that must be done after sections have been combined.
-    fn post_init(&mut self, _sections: &[Section], _symbols: &[Symbol], _symbol_indices: &[usize]) {}
+    fn post_init(&mut self, _sections: &[Section], _symbols: &[Symbol], _symbol_indices: &[usize]) {
+    }
 
     /// Generate a list of instructions references (offset, size, opcode) from the given code.
     ///

--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -340,7 +340,7 @@ impl dyn Arch {
 
 pub trait Arch: Any + Debug + Send + Sync {
     /// Finishes arch-specific initialization that must be done after sections have been combined.
-    fn post_init(&mut self, _sections: &[Section], _symbols: &[Symbol]) {}
+    fn post_init(&mut self, _sections: &[Section], _symbols: &[Symbol], _symbol_indices: &[usize]) {}
 
     /// Generate a list of instructions references (offset, size, opcode) from the given code.
     ///

--- a/objdiff-core/src/arch/ppc/mod.rs
+++ b/objdiff-core/src/arch/ppc/mod.rs
@@ -476,13 +476,11 @@ impl Arch for ArchPpc {
     fn post_init(&mut self, _sections: &[Section], _symbols: &[Symbol], symbol_indices: &[usize]) {
         // Change the indices used as keys from the original symbol indices to the new symbol array indices
         if let Some(extab) = self.extab.as_ref() {
-            let new_map: BTreeMap<usize, ExceptionInfo> = extab.iter().map(|e| {
-                (symbol_indices[*e.0 + 1], e.1.clone())
-            }).collect();
+            let new_map: BTreeMap<usize, ExceptionInfo> =
+                extab.iter().map(|e| (symbol_indices[*e.0 + 1], e.1.clone())).collect();
 
             self.extab.replace(new_map);
         }
-
     }
 }
 

--- a/objdiff-core/src/arch/ppc/mod.rs
+++ b/objdiff-core/src/arch/ppc/mod.rs
@@ -475,9 +475,7 @@ impl Arch for ArchPpc {
 
     fn post_init(&mut self, _sections: &[Section], _symbols: &[Symbol], symbol_indices: &[usize]) {
         // Change the indices used as keys from the original symbol indices to the new symbol array indices
-        if let Some(new_map) = Self::convert_extab_map_indices(self, symbol_indices) {
-            self.extab.replace(new_map);
-        }
+        self.extab = Self::convert_extab_map_indices(self, symbol_indices);
     }
 }
 
@@ -488,7 +486,7 @@ impl ArchPpc {
 
     pub fn convert_extab_map_indices(
         &self,
-        symbol_indices: &[usize]
+        symbol_indices: &[usize],
     ) -> Option<BTreeMap<usize, ExceptionInfo>> {
         let new_map: BTreeMap<usize, ExceptionInfo> =
             self.extab.as_ref()?.iter().map(|e| (symbol_indices[*e.0 + 1], e.1.clone())).collect();

--- a/objdiff-core/src/arch/ppc/mod.rs
+++ b/objdiff-core/src/arch/ppc/mod.rs
@@ -475,10 +475,7 @@ impl Arch for ArchPpc {
 
     fn post_init(&mut self, _sections: &[Section], _symbols: &[Symbol], symbol_indices: &[usize]) {
         // Change the indices used as keys from the original symbol indices to the new symbol array indices
-        if let Some(extab) = self.extab.as_ref() {
-            let new_map: BTreeMap<usize, ExceptionInfo> =
-                extab.iter().map(|e| (symbol_indices[*e.0 + 1], e.1.clone())).collect();
-
+        if let Some(new_map) = Self::convert_extab_map_indices(&self, symbol_indices) {
             self.extab.replace(new_map);
         }
     }
@@ -487,6 +484,13 @@ impl Arch for ArchPpc {
 impl ArchPpc {
     pub fn extab_for_symbol(&self, symbol_index: usize) -> Option<&ExceptionInfo> {
         self.extab.as_ref()?.get(&symbol_index)
+    }
+
+    pub fn convert_extab_map_indices(&self, symbol_indices: &[usize]) -> Option<BTreeMap<usize, ExceptionInfo>> {
+        let new_map: BTreeMap<usize, ExceptionInfo> =
+            self.extab.as_ref()?.iter().map(|e| (symbol_indices[*e.0 + 1], e.1.clone())).collect();
+
+        return Some(new_map)
     }
 }
 

--- a/objdiff-core/src/arch/ppc/mod.rs
+++ b/objdiff-core/src/arch/ppc/mod.rs
@@ -472,6 +472,18 @@ impl Arch for ArchPpc {
         }
         Ok(next_address.saturating_sub(symbol.address))
     }
+
+    fn post_init(&mut self, _sections: &[Section], _symbols: &[Symbol], symbol_indices: &[usize]) {
+        // Change the indices used as keys from the original symbol indices to the new symbol array indices
+        if let Some(extab) = self.extab.as_ref() {
+            let new_map: BTreeMap<usize, ExceptionInfo> = extab.iter().map(|e| {
+                (symbol_indices[*e.0 + 1], e.1.clone())
+            }).collect();
+
+            self.extab.replace(new_map);
+        }
+
+    }
 }
 
 impl ArchPpc {

--- a/objdiff-core/src/arch/ppc/mod.rs
+++ b/objdiff-core/src/arch/ppc/mod.rs
@@ -475,7 +475,7 @@ impl Arch for ArchPpc {
 
     fn post_init(&mut self, _sections: &[Section], _symbols: &[Symbol], symbol_indices: &[usize]) {
         // Change the indices used as keys from the original symbol indices to the new symbol array indices
-        if let Some(new_map) = Self::convert_extab_map_indices(&self, symbol_indices) {
+        if let Some(new_map) = Self::convert_extab_map_indices(self, symbol_indices) {
             self.extab.replace(new_map);
         }
     }
@@ -486,11 +486,14 @@ impl ArchPpc {
         self.extab.as_ref()?.get(&symbol_index)
     }
 
-    pub fn convert_extab_map_indices(&self, symbol_indices: &[usize]) -> Option<BTreeMap<usize, ExceptionInfo>> {
+    pub fn convert_extab_map_indices(
+        &self,
+        symbol_indices: &[usize]
+    ) -> Option<BTreeMap<usize, ExceptionInfo>> {
         let new_map: BTreeMap<usize, ExceptionInfo> =
             self.extab.as_ref()?.iter().map(|e| (symbol_indices[*e.0 + 1], e.1.clone())).collect();
 
-        return Some(new_map)
+        Some(new_map)
     }
 }
 

--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -1089,7 +1089,7 @@ pub fn parse(data: &[u8], config: &DiffObjConfig, diff_side: DiffSide) -> Result
         combine_sections(&mut sections, &mut symbols, config)?;
     }
     add_section_symbols(&sections, &mut symbols);
-    arch.post_init(&sections, &symbols);
+    arch.post_init(&sections, &symbols, &symbol_indices);
     let mut obj = Object {
         arch,
         endianness: obj_file.endianness(),

--- a/objdiff-core/tests/snapshots/arch_ppc__read_extab.snap
+++ b/objdiff-core/tests/snapshots/arch_ppc__read_extab.snap
@@ -9,7 +9,7 @@ Object {
         ),
         extab: Some(
             {
-                10: ExceptionInfo {
+                1: ExceptionInfo {
                     eti_symbol: ExtabSymbolRef {
                         original_index: 5,
                         name: "@31",
@@ -35,7 +35,7 @@ Object {
                     },
                     dtors: [],
                 },
-                11: ExceptionInfo {
+                2: ExceptionInfo {
                     eti_symbol: ExtabSymbolRef {
                         original_index: 7,
                         name: "@52",
@@ -95,7 +95,7 @@ Object {
                         },
                     ],
                 },
-                12: ExceptionInfo {
+                3: ExceptionInfo {
                     eti_symbol: ExtabSymbolRef {
                         original_index: 9,
                         name: "@60",


### PR DESCRIPTION
This is kind of a messy workaround imo that should be replaced with a more proper solution, but doing that would require significant changes to allow extab decoding to happen after the symbol data is parsed, so I guess this is fine for now. The main obstacle is changing map_symbol so the check that involves checking the extab map can happen later, which might end up being even messier than this solution.