### PR TITLE
Bump Object Crate to 0.39.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "63944c133d03f44e75866bbd160b95af0ec3f6a13d936d69d31c81078cbc5baf"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63944c133d03f44e75866bbd160b95af0ec3f6a13d936d69d31c81078cbc5baf"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "memchr",
 ]

--- a/objdiff-core/Cargo.toml
+++ b/objdiff-core/Cargo.toml
@@ -132,7 +132,7 @@ itertools = { version = "0.14", default-features = false, features = ["use_alloc
 log = { version = "0.4", default-features = false, optional = true }
 memmap2 = { version = "0.9", optional = true }
 num-traits = { version = "0.2", default-features = false, optional = true }
-object = { version = "0.37", default-features = false, features = ["read_core", "elf", "coff"] }
+object = { version = "0.39", default-features = false, features = ["read_core", "elf", "coff"] }
 pbjson = { version = "0.8", default-features = false, optional = true }
 prost = { version = "0.14", default-features = false, features = ["derive"], optional = true }
 regex = { version = "1.12", default-features = false, features = [], optional = true }

--- a/objdiff-core/Cargo.toml
+++ b/objdiff-core/Cargo.toml
@@ -132,7 +132,7 @@ itertools = { version = "0.14", default-features = false, features = ["use_alloc
 log = { version = "0.4", default-features = false, optional = true }
 memmap2 = { version = "0.9", optional = true }
 num-traits = { version = "0.2", default-features = false, optional = true }
-object = { version = "0.39", default-features = false, features = ["read_core", "elf", "coff"] }
+object = { version = "0.39.1", default-features = false, features = ["read_core", "elf", "coff"] }
 pbjson = { version = "0.8", default-features = false, optional = true }
 prost = { version = "0.14", default-features = false, features = ["derive"], optional = true }
 regex = { version = "1.12", default-features = false, features = [], optional = true }

--- a/objdiff-core/src/arch/arm.rs
+++ b/objdiff-core/src/arch/arm.rs
@@ -352,7 +352,7 @@ impl Arch for ArchArm {
                         | elf::R_ARM_CALL
                         | elf::R_ARM_JUMP24 => {
                             let data = section_data[address..address + 4].try_into()?;
-                            let addend = self.endianness.read_i32_bytes(data);
+                            let addend = self.endianness.read_i32(data);
                             let imm24 = addend & 0xffffff;
                             (imm24 << 2) << 8 >> 8
                         }
@@ -360,9 +360,9 @@ impl Arch for ArchArm {
                         // Thumb calls
                         elf::R_ARM_THM_PC22 | elf::R_ARM_THM_XPC22 => {
                             let data = section_data[address..address + 2].try_into()?;
-                            let high = self.endianness.read_i16_bytes(data) as i32;
+                            let high = self.endianness.read_i16(data) as i32;
                             let data = section_data[address + 2..address + 4].try_into()?;
-                            let low = self.endianness.read_i16_bytes(data) as i32;
+                            let low = self.endianness.read_i16(data) as i32;
 
                             let imm22 = ((high & 0x7ff) << 11) | (low & 0x7ff);
                             (imm22 << 1) << 9 >> 9
@@ -371,7 +371,7 @@ impl Arch for ArchArm {
                         // Thumb unconditional branch (B, 11-bit offset)
                         elf::R_ARM_THM_PC11 => {
                             let data = section_data[address..address + 2].try_into()?;
-                            let insn = self.endianness.read_u16_bytes(data) as i32;
+                            let insn = self.endianness.read_u16(data) as i32;
                             let imm11 = insn & 0x7ff;
                             (imm11 << 1) << 20 >> 20
                         }
@@ -379,7 +379,7 @@ impl Arch for ArchArm {
                         // Thumb conditional branch (B<cond>, 8-bit offset)
                         elf::R_ARM_THM_PC9 => {
                             let data = section_data[address..address + 2].try_into()?;
-                            let insn = self.endianness.read_u16_bytes(data) as i32;
+                            let insn = self.endianness.read_u16(data) as i32;
                             let imm8 = insn & 0xff;
                             (imm8 << 1) << 23 >> 23
                         }
@@ -387,7 +387,7 @@ impl Arch for ArchArm {
                         // Data
                         elf::R_ARM_ABS32 => {
                             let data = section_data[address..address + 4].try_into()?;
-                            self.endianness.read_i32_bytes(data)
+                            self.endianness.read_i32(data)
                         }
 
                         flags => bail!("Unsupported ARM implicit relocation {flags:?}"),

--- a/objdiff-core/src/arch/mips.rs
+++ b/objdiff-core/src/arch/mips.rs
@@ -77,7 +77,7 @@ impl ArchMips {
             .and_then(|section| section.data().ok())
             .and_then(|data| data.get(0x14..0x18))
             .and_then(|s| s.try_into().ok())
-            .map(|bytes| endianness.read_i32_bytes(bytes))
+            .map(|bytes| endianness.read_i32(bytes))
             .unwrap_or(0);
 
         // Parse all relocations to pair R_MIPS_HI16 and R_MIPS_LO16. Since the instructions only
@@ -98,13 +98,13 @@ impl ArchMips {
                 match reloc.flags() {
                     object::RelocationFlags::Elf { r_type: elf::R_MIPS_HI16 } => {
                         let code = data[addr as usize..addr as usize + 4].try_into()?;
-                        let addend = ((endianness.read_u32_bytes(code) & 0x0000FFFF) << 16) as i32;
+                        let addend = ((endianness.read_u32(code) & 0x0000FFFF) << 16) as i32;
                         last_hi = Some(addr);
                         last_hi_addend = addend;
                     }
                     object::RelocationFlags::Elf { r_type: elf::R_MIPS_LO16 } => {
                         let code = data[addr as usize..addr as usize + 4].try_into()?;
-                        let addend = (endianness.read_u32_bytes(code) & 0x0000FFFF) as i16 as i32;
+                        let addend = (endianness.read_u32(code) & 0x0000FFFF) as i16 as i32;
                         let full_addend = (last_hi_addend + addend) as i64;
                         if let Some(hi_addr) = last_hi.take() {
                             addends.insert(hi_addr, full_addend);
@@ -197,7 +197,7 @@ impl ArchMips {
         diff_config: &DiffObjConfig,
     ) -> Result<rabbitizer::Instruction> {
         Ok(rabbitizer::Instruction::new(
-            self.endianness.read_u32_bytes(code.try_into()?),
+            self.endianness.read_u32(code.try_into()?),
             Vram::new(ins_ref.address as u32),
             self.instruction_flags(diff_config),
         ))
@@ -217,7 +217,7 @@ impl Arch for ArchMips {
         let mut ops = Vec::<InstructionRef>::with_capacity(code.len() / 4);
         let mut cur_addr = address as u32;
         for chunk in code.chunks_exact(4) {
-            let code = self.endianness.read_u32_bytes(chunk.try_into()?);
+            let code = self.endianness.read_u32(chunk.try_into()?);
             let instruction =
                 rabbitizer::Instruction::new(code, Vram::new(cur_addr), instruction_flags);
             let opcode = instruction.opcode() as u16;
@@ -269,7 +269,7 @@ impl Arch for ArchMips {
                     let data = section.data()?;
                     let code = self
                         .endianness
-                        .read_u32_bytes(data[address as usize..address as usize + 4].try_into()?);
+                        .read_u32(data[address as usize..address as usize + 4].try_into()?);
                     let addend = match r_type {
                         elf::R_MIPS_32 => code as i64,
                         elf::R_MIPS_26 => ((code & 0x03FFFFFF) << 2) as i64,
@@ -366,7 +366,7 @@ impl Arch for ArchMips {
             && new_address >= symbol.address + 4
             && let Some(data) = section.data_range(new_address - 4, 4)
             && let instruction = rabbitizer::Instruction::new(
-                self.endianness.read_u32_bytes(data.try_into().unwrap()),
+                self.endianness.read_u32(data.try_into().unwrap()),
                 Vram::new((new_address - 4) as u32),
                 self.default_instruction_flags(),
             )

--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -125,7 +125,7 @@ impl DataType {
                 }
             }
             DataType::Int16 => {
-                let i = endian.read_i16_bytes(bytes.try_into().unwrap());
+                let i = endian.read_i16(bytes.try_into().unwrap());
                 strs.push((format!("{i:#x}"), None, None));
 
                 if i < 0 {
@@ -133,7 +133,7 @@ impl DataType {
                 }
             }
             DataType::Int32 => {
-                let i = endian.read_i32_bytes(bytes.try_into().unwrap());
+                let i = endian.read_i32(bytes.try_into().unwrap());
                 strs.push((format!("{i:#x}"), None, None));
 
                 if i < 0 {
@@ -141,7 +141,7 @@ impl DataType {
                 }
             }
             DataType::Int64 => {
-                let i = endian.read_i64_bytes(bytes.try_into().unwrap());
+                let i = endian.read_i64(bytes.try_into().unwrap());
                 strs.push((format!("{i:#x}"), None, None));
 
                 if i < 0 {

--- a/objdiff-core/src/arch/mod.rs
+++ b/objdiff-core/src/arch/mod.rs
@@ -151,7 +151,7 @@ impl DataType {
                 }
             }
             DataType::Int16 => {
-                let i = endian.read_i16_bytes(bytes.try_into().unwrap());
+                let i = endian.read_i16(bytes.try_into().unwrap());
                 strs.push(LiteralInfo { literal: format!("{i:#x}"), ..Default::default() });
 
                 if i < 0 {
@@ -162,7 +162,7 @@ impl DataType {
                 }
             }
             DataType::Int32 => {
-                let i = endian.read_i32_bytes(bytes.try_into().unwrap());
+                let i = endian.read_i32(bytes.try_into().unwrap());
                 strs.push(LiteralInfo { literal: format!("{i:#x}"), ..Default::default() });
 
                 if i < 0 {
@@ -173,7 +173,7 @@ impl DataType {
                 }
             }
             DataType::Int64 => {
-                let i = endian.read_i64_bytes(bytes.try_into().unwrap());
+                let i = endian.read_i64(bytes.try_into().unwrap());
                 strs.push(LiteralInfo { literal: format!("{i:#x}"), ..Default::default() });
 
                 if i < 0 {

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -193,8 +193,8 @@ impl Arch for ArchX86 {
         if resolved.ins_ref.opcode == OPCODE_DATA {
             let (mnemonic, imm) = match resolved.ins_ref.size {
                 1 => (".byte", resolved.code[0] as u64),
-                2 => (".word", self.endianness.read_u16_bytes(resolved.code.try_into()?) as u64),
-                4 => (".dword", self.endianness.read_u32_bytes(resolved.code.try_into()?) as u64),
+                2 => (".word", self.endianness.read_u16(resolved.code.try_into()?) as u64),
+                4 => (".dword", self.endianness.read_u32(resolved.code.try_into()?) as u64),
                 _ => bail!("Unsupported x86 inline data size {}", resolved.ins_ref.size),
             };
             cb(InstructionPart::opcode(mnemonic, OPCODE_DATA))?;
@@ -288,7 +288,7 @@ impl Arch for ArchX86 {
                 } => {
                     let data =
                         section.data()?[address as usize..address as usize + 4].try_into()?;
-                    self.endianness.read_i32_bytes(data) as i64
+                    self.endianness.read_i32(data) as i64
                 }
                 flags => bail!("Unsupported x86 implicit relocation {flags:?}"),
             },
@@ -299,13 +299,13 @@ impl Arch for ArchX86 {
                 | object::RelocationFlags::Elf { r_type: elf::R_X86_64_32 | elf::R_X86_64_PC32 } => {
                     let data =
                         section.data()?[address as usize..address as usize + 4].try_into()?;
-                    self.endianness.read_i32_bytes(data) as i64
+                    self.endianness.read_i32(data) as i64
                 }
                 object::RelocationFlags::Coff { typ: pe::IMAGE_REL_AMD64_ADDR64 }
                 | object::RelocationFlags::Elf { r_type: elf::R_X86_64_64 } => {
                     let data =
                         section.data()?[address as usize..address as usize + 8].try_into()?;
-                    self.endianness.read_i64_bytes(data)
+                    self.endianness.read_i64(data)
                 }
                 flags => bail!("Unsupported x86-64 implicit relocation {flags:?}"),
             },

--- a/objdiff-core/src/obj/split_meta.rs
+++ b/objdiff-core/src/obj/split_meta.rs
@@ -61,8 +61,7 @@ impl SplitMeta {
                     let vec = if is_64 {
                         let mut vec = vec![0u64; note.desc.len() / 8];
                         for (i, v) in vec.iter_mut().enumerate() {
-                            *v =
-                                e.read_u64(note.desc[i * 8..(i + 1) * 8].try_into().unwrap());
+                            *v = e.read_u64(note.desc[i * 8..(i + 1) * 8].try_into().unwrap());
                         }
                         vec
                     } else {

--- a/objdiff-core/src/obj/split_meta.rs
+++ b/objdiff-core/src/obj/split_meta.rs
@@ -53,7 +53,7 @@ impl SplitMeta {
                     result.module_name = Some(string);
                 }
                 NT_SPLIT_MODULE_ID => {
-                    result.module_id = Some(e.read_u32_bytes(
+                    result.module_id = Some(e.read_u32(
                         note.desc.try_into().map_err(|_| anyhow!("Invalid module ID size"))?,
                     ));
                 }
@@ -61,14 +61,13 @@ impl SplitMeta {
                     let vec = if is_64 {
                         let mut vec = vec![0u64; note.desc.len() / 8];
                         for (i, v) in vec.iter_mut().enumerate() {
-                            *v =
-                                e.read_u64_bytes(note.desc[i * 8..(i + 1) * 8].try_into().unwrap());
+                            *v = e.read_u64(note.desc[i * 8..(i + 1) * 8].try_into().unwrap());
                         }
                         vec
                     } else {
                         let mut vec = vec![0u64; note.desc.len() / 4];
                         for (i, v) in vec.iter_mut().enumerate() {
-                            *v = e.read_u32_bytes(note.desc[i * 4..(i + 1) * 4].try_into().unwrap())
+                            *v = e.read_u32(note.desc[i * 4..(i + 1) * 4].try_into().unwrap())
                                 as u64;
                         }
                         vec
@@ -101,7 +100,7 @@ impl SplitMeta {
         }
         if let Some(module_id) = self.module_id {
             write_note_header(writer, e, NT_SPLIT_MODULE_ID, 4)?;
-            writer.write_all(&e.write_u32_bytes(module_id))?;
+            writer.write_all(&e.write_u32(module_id))?;
         }
         if let Some(virtual_addresses) = &self.virtual_addresses {
             let count = virtual_addresses.len();
@@ -109,11 +108,11 @@ impl SplitMeta {
             write_note_header(writer, e, NT_SPLIT_VIRTUAL_ADDRESSES, size)?;
             if is_64 {
                 for &addr in virtual_addresses {
-                    writer.write_all(&e.write_u64_bytes(addr))?;
+                    writer.write_all(&e.write_u64(addr))?;
                 }
             } else {
                 for &addr in virtual_addresses {
-                    writer.write_all(&e.write_u32_bytes(addr as u32))?;
+                    writer.write_all(&e.write_u32(addr as u32))?;
                 }
             }
         }
@@ -208,9 +207,9 @@ where
     E: Endian,
     W: std::io::Write + ?Sized,
 {
-    writer.write_all(&e.write_u32_bytes(ELF_NOTE_SPLIT.len() as u32 + 1))?; // Name Size
-    writer.write_all(&e.write_u32_bytes(desc_len as u32))?; // Desc Size
-    writer.write_all(&e.write_u32_bytes(kind))?; // Type
+    writer.write_all(&e.write_u32(ELF_NOTE_SPLIT.len() as u32 + 1))?; // Name Size
+    writer.write_all(&e.write_u32(desc_len as u32))?; // Desc Size
+    writer.write_all(&e.write_u32(kind))?; // Type
     writer.write_all(ELF_NOTE_SPLIT)?; // Name
     writer.write_all(&[0; 1])?; // Null terminator
     align_data_to_4(writer, ELF_NOTE_SPLIT.len() + 1)?;

--- a/objdiff-core/src/obj/split_meta.rs
+++ b/objdiff-core/src/obj/split_meta.rs
@@ -53,7 +53,7 @@ impl SplitMeta {
                     result.module_name = Some(string);
                 }
                 NT_SPLIT_MODULE_ID => {
-                    result.module_id = Some(e.read_u32_bytes(
+                    result.module_id = Some(e.read_u32(
                         note.desc.try_into().map_err(|_| anyhow!("Invalid module ID size"))?,
                     ));
                 }
@@ -62,13 +62,13 @@ impl SplitMeta {
                         let mut vec = vec![0u64; note.desc.len() / 8];
                         for (i, v) in vec.iter_mut().enumerate() {
                             *v =
-                                e.read_u64_bytes(note.desc[i * 8..(i + 1) * 8].try_into().unwrap());
+                                e.read_u64(note.desc[i * 8..(i + 1) * 8].try_into().unwrap());
                         }
                         vec
                     } else {
                         let mut vec = vec![0u64; note.desc.len() / 4];
                         for (i, v) in vec.iter_mut().enumerate() {
-                            *v = e.read_u32_bytes(note.desc[i * 4..(i + 1) * 4].try_into().unwrap())
+                            *v = e.read_u32(note.desc[i * 4..(i + 1) * 4].try_into().unwrap())
                                 as u64;
                         }
                         vec
@@ -101,7 +101,7 @@ impl SplitMeta {
         }
         if let Some(module_id) = self.module_id {
             write_note_header(writer, e, NT_SPLIT_MODULE_ID, 4)?;
-            writer.write_all(&e.write_u32_bytes(module_id))?;
+            writer.write_all(&e.write_u32(module_id))?;
         }
         if let Some(virtual_addresses) = &self.virtual_addresses {
             let count = virtual_addresses.len();
@@ -109,11 +109,11 @@ impl SplitMeta {
             write_note_header(writer, e, NT_SPLIT_VIRTUAL_ADDRESSES, size)?;
             if is_64 {
                 for &addr in virtual_addresses {
-                    writer.write_all(&e.write_u64_bytes(addr))?;
+                    writer.write_all(&e.write_u64(addr))?;
                 }
             } else {
                 for &addr in virtual_addresses {
-                    writer.write_all(&e.write_u32_bytes(addr as u32))?;
+                    writer.write_all(&e.write_u32(addr as u32))?;
                 }
             }
         }
@@ -208,9 +208,9 @@ where
     E: Endian,
     W: std::io::Write + ?Sized,
 {
-    writer.write_all(&e.write_u32_bytes(ELF_NOTE_SPLIT.len() as u32 + 1))?; // Name Size
-    writer.write_all(&e.write_u32_bytes(desc_len as u32))?; // Desc Size
-    writer.write_all(&e.write_u32_bytes(kind))?; // Type
+    writer.write_all(&e.write_u32(ELF_NOTE_SPLIT.len() as u32 + 1))?; // Name Size
+    writer.write_all(&e.write_u32(desc_len as u32))?; // Desc Size
+    writer.write_all(&e.write_u32(kind))?; // Type
     writer.write_all(ELF_NOTE_SPLIT)?; // Name
     writer.write_all(&[0; 1])?; // Null terminator
     align_data_to_4(writer, ELF_NOTE_SPLIT.len() + 1)?;

--- a/objdiff-core/src/util.rs
+++ b/objdiff-core/src/util.rs
@@ -28,14 +28,14 @@ impl<N: PrimInt> fmt::UpperHex for ReallySigned<N> {
 
 pub fn read_u32(obj_file: &object::File, reader: &mut &[u8]) -> Result<u32> {
     ensure!(reader.len() >= 4, "Not enough bytes to read u32");
-    let value = u32::from_ne_bytes(reader[..4].try_into()?);
+    let value = reader[..4].try_into()?;
     *reader = &reader[4..];
     Ok(obj_file.endianness().read_u32(value))
 }
 
 pub fn read_u16(obj_file: &object::File, reader: &mut &[u8]) -> Result<u16> {
     ensure!(reader.len() >= 2, "Not enough bytes to read u16");
-    let value = u16::from_ne_bytes(reader[..2].try_into()?);
+    let value = reader[..2].try_into()?;
     *reader = &reader[2..];
     Ok(obj_file.endianness().read_u16(value))
 }


### PR DESCRIPTION
Bumping object crate to version 0.39.0

I ran into a strange issue with a custom generated ARM object file that had data that wasn't aligned to an expected value. The object crate was fussy about it and it's now been resolved.

See the following issue and commits
https://github.com/gimli-rs/object/issues/848
https://github.com/gimli-rs/object/pull/861