### PR TITLE
Strip trailing int3 instructions (alignment padding) for x64

### DIFF
--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -183,7 +183,7 @@ impl Arch for ArchX86 {
         }
         // Strip trailing int3 instructions (alignment padding) for x64
         if matches!(self.arch, Architecture::X86_64) {
-            while out.last().map_or(false, |i| i.opcode == iced_x86::Mnemonic::Int3 as u16) {
+            while out.last().is_some_and(|i| i.opcode == iced_x86::Mnemonic::Int3 as u16) {
                 out.pop();
             }
         }

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -181,6 +181,12 @@ impl Arch for ArchX86 {
                 branch_dest,
             });
         }
+        // Strip trailing int3 instructions (alignment padding) for x64
+        if matches!(self.arch, Architecture::X86_64) {
+            while out.last().map(|i| i.opcode == iced_x86::Mnemonic::Int3 as u16).unwrap_or(false) {
+                out.pop();
+            }
+        }
         Ok(out)
     }
 

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -183,7 +183,7 @@ impl Arch for ArchX86 {
         }
         // Strip trailing int3 instructions (alignment padding) for x64
         if matches!(self.arch, Architecture::X86_64) {
-            while out.last().map(|i| i.opcode == iced_x86::Mnemonic::Int3 as u16).unwrap_or(false) {
+            while out.last().map_or(false, |i| i.opcode == iced_x86::Mnemonic::Int3 as u16) {
                 out.pop();
             }
         }


### PR DESCRIPTION
Trying to do some comparison against objects compiled for x64 code with VS2012 17.0.65501.17028

The functions have unreliable sizes due to padding where a function may be 3 bytes large, but after adding a second function it will pad out to 16 byte alignment. However the newly added function is still only 1 byte aligned. This change removes trailing `int3` instructions for comparison which are used to pad x64.

Before matching %
<img width="974" height="411" alt="image" src="https://github.com/user-attachments/assets/18c48f68-24a5-4e21-bed9-28761dd4af9f" />

Problem instructions
<img width="1348" height="553" alt="image" src="https://github.com/user-attachments/assets/27666f87-ad2d-40dd-9d29-6845fbbdda1d" />

After %
<img width="974" height="411" alt="image" src="https://github.com/user-attachments/assets/581c53cc-591e-4291-b02b-c4beefb12f31" />
