### PR TITLE
Add missing x64 relocation types

### DIFF
--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -300,13 +300,14 @@ impl Arch for ArchX86 {
             },
             Architecture::X86_64 => match relocation.flags() {
                 object::RelocationFlags::Coff {
-                    typ: pe::IMAGE_REL_AMD64_ADDR32NB
-                    | pe::IMAGE_REL_AMD64_REL32
-                    | pe::IMAGE_REL_AMD64_REL32_1
-                    | pe::IMAGE_REL_AMD64_REL32_2
-                    | pe::IMAGE_REL_AMD64_REL32_3
-                    | pe::IMAGE_REL_AMD64_REL32_4
-                    | pe::IMAGE_REL_AMD64_REL32_5,
+                    typ:
+                        pe::IMAGE_REL_AMD64_ADDR32NB
+                        | pe::IMAGE_REL_AMD64_REL32
+                        | pe::IMAGE_REL_AMD64_REL32_1
+                        | pe::IMAGE_REL_AMD64_REL32_2
+                        | pe::IMAGE_REL_AMD64_REL32_3
+                        | pe::IMAGE_REL_AMD64_REL32_4
+                        | pe::IMAGE_REL_AMD64_REL32_5,
                 }
                 | object::RelocationFlags::Elf { r_type: elf::R_X86_64_32 | elf::R_X86_64_PC32 } => {
                     let data =

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -80,7 +80,13 @@ impl ArchX86 {
             },
             Architecture::X86_64 => match flags {
                 RelocationFlags::Coff(typ) => match typ {
-                    pe::IMAGE_REL_AMD64_ADDR32NB | pe::IMAGE_REL_AMD64_REL32 => Some(4),
+                    pe::IMAGE_REL_AMD64_ADDR32NB
+                    | pe::IMAGE_REL_AMD64_REL32
+                    | pe::IMAGE_REL_AMD64_REL32_1
+                    | pe::IMAGE_REL_AMD64_REL32_2
+                    | pe::IMAGE_REL_AMD64_REL32_3
+                    | pe::IMAGE_REL_AMD64_REL32_4
+                    | pe::IMAGE_REL_AMD64_REL32_5 => Some(4),
                     pe::IMAGE_REL_AMD64_ADDR64 => Some(8),
                     _ => None,
                 },
@@ -294,7 +300,13 @@ impl Arch for ArchX86 {
             },
             Architecture::X86_64 => match relocation.flags() {
                 object::RelocationFlags::Coff {
-                    typ: pe::IMAGE_REL_AMD64_ADDR32NB | pe::IMAGE_REL_AMD64_REL32,
+                    typ: pe::IMAGE_REL_AMD64_ADDR32NB
+                    | pe::IMAGE_REL_AMD64_REL32
+                    | pe::IMAGE_REL_AMD64_REL32_1
+                    | pe::IMAGE_REL_AMD64_REL32_2
+                    | pe::IMAGE_REL_AMD64_REL32_3
+                    | pe::IMAGE_REL_AMD64_REL32_4
+                    | pe::IMAGE_REL_AMD64_REL32_5,
                 }
                 | object::RelocationFlags::Elf { r_type: elf::R_X86_64_32 | elf::R_X86_64_PC32 } => {
                     let data =
@@ -337,6 +349,11 @@ impl Arch for ArchX86 {
                     pe::IMAGE_REL_AMD64_ADDR64 => Some("IMAGE_REL_AMD64_ADDR64"),
                     pe::IMAGE_REL_AMD64_ADDR32NB => Some("IMAGE_REL_AMD64_ADDR32NB"),
                     pe::IMAGE_REL_AMD64_REL32 => Some("IMAGE_REL_AMD64_REL32"),
+                    pe::IMAGE_REL_AMD64_REL32_1 => Some("IMAGE_REL_AMD64_REL32_1"),
+                    pe::IMAGE_REL_AMD64_REL32_2 => Some("IMAGE_REL_AMD64_REL32_2"),
+                    pe::IMAGE_REL_AMD64_REL32_3 => Some("IMAGE_REL_AMD64_REL32_3"),
+                    pe::IMAGE_REL_AMD64_REL32_4 => Some("IMAGE_REL_AMD64_REL32_4"),
+                    pe::IMAGE_REL_AMD64_REL32_5 => Some("IMAGE_REL_AMD64_REL32_5"),
                     _ => None,
                 },
                 _ => None,

--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -86,7 +86,8 @@ impl ArchX86 {
                     | pe::IMAGE_REL_AMD64_REL32_2
                     | pe::IMAGE_REL_AMD64_REL32_3
                     | pe::IMAGE_REL_AMD64_REL32_4
-                    | pe::IMAGE_REL_AMD64_REL32_5 => Some(4),
+                    | pe::IMAGE_REL_AMD64_REL32_5
+                    | pe::IMAGE_REL_AMD64_SECREL => Some(4),
                     pe::IMAGE_REL_AMD64_ADDR64 => Some(8),
                     _ => None,
                 },
@@ -307,7 +308,8 @@ impl Arch for ArchX86 {
                         | pe::IMAGE_REL_AMD64_REL32_2
                         | pe::IMAGE_REL_AMD64_REL32_3
                         | pe::IMAGE_REL_AMD64_REL32_4
-                        | pe::IMAGE_REL_AMD64_REL32_5,
+                        | pe::IMAGE_REL_AMD64_REL32_5
+                        | pe::IMAGE_REL_AMD64_SECREL,
                 }
                 | object::RelocationFlags::Elf { r_type: elf::R_X86_64_32 | elf::R_X86_64_PC32 } => {
                     let data =
@@ -355,6 +357,7 @@ impl Arch for ArchX86 {
                     pe::IMAGE_REL_AMD64_REL32_3 => Some("IMAGE_REL_AMD64_REL32_3"),
                     pe::IMAGE_REL_AMD64_REL32_4 => Some("IMAGE_REL_AMD64_REL32_4"),
                     pe::IMAGE_REL_AMD64_REL32_5 => Some("IMAGE_REL_AMD64_REL32_5"),
+                    pe::IMAGE_REL_AMD64_SECREL => Some("IMAGE_REL_AMD64_SECREL"),
                     _ => None,
                 },
                 _ => None,


### PR DESCRIPTION
Added some missing x64 relocation types

Before
<img width="950" height="521" alt="image" src="https://github.com/user-attachments/assets/e027f756-1e42-4791-b1da-8ff4df027cad" />


After
<img width="950" height="521" alt="image" src="https://github.com/user-attachments/assets/57a0b097-8e78-4958-84a3-6f0aaad20dbc" />
