### PR TITLE
ARM: Fix index out of bounds error when there are no mapping symbols

### DIFF
--- a/objdiff-core/src/arch/arm.rs
+++ b/objdiff-core/src/arch/arm.rs
@@ -183,7 +183,7 @@ impl Arch for ArchArm {
         let mapping_symbols = self
             .disasm_modes
             .get(&section_index)
-            .map(|x| x.as_slice())
+            .map(|x| if x.is_empty() { &fallback_mappings } else { x.as_slice() })
             .unwrap_or(&fallback_mappings);
         let first_mapping_idx = mapping_symbols
             .binary_search_by_key(&start_addr, |x| x.address)


### PR DESCRIPTION
Fixes #352.

Related PR: #183. Similar to that PR, I suspect this object is invalid and DSD itself is bugged, but just adding a quick fix to avoid the panic for now.