### PR TITLE
Fix armcc symbols always being hidden

### DIFF
--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -9,7 +9,7 @@ use alloc::{
 use core::{cmp::Ordering, num::NonZeroU64};
 
 use anyhow::{Context, Result, anyhow, bail, ensure};
-use object::{Object as _, ObjectSection as _, ObjectSymbol as _};
+use object::{Architecture, Object as _, ObjectSection as _, ObjectSymbol as _};
 
 use crate::{
     arch::{Arch, RelocationOverride, RelocationOverrideTarget, new_arch},
@@ -133,7 +133,9 @@ fn map_symbol(
     if symbol.is_weak() {
         flags |= SymbolFlag::Weak;
     }
-    if file.format() == object::BinaryFormat::Elf && symbol.scope() == object::SymbolScope::Linkage
+    if file.format() == object::BinaryFormat::Elf
+        && symbol.scope() == object::SymbolScope::Linkage
+        && (file.architecture() != Architecture::Arm || !symbol.is_global())
     {
         flags |= SymbolFlag::Hidden;
     }


### PR DESCRIPTION
For some reason armcc always marks global symbols as hidden (referred to as `Linkage` by the `object` library) which makes objdiff never display any non-static functions unless the "Show hidden symbols" option is enabled, which is an undesirable workaround because that always adds a lot of noise symbols.

This fixes it by never hiding any global symbols in ARM ELF objects. I don't know if this causes any collateral damage in non-armcc ecosystems but armcc only ever marks actual function symbols as global so it works.