### PR TITLE
x86: don't infinite-loop when an inline-data relocation overruns the symbol

### DIFF
--- a/objdiff-core/src/arch/x86.rs
+++ b/objdiff-core/src/arch/x86.rs
@@ -169,6 +169,15 @@ impl Arch for ArchX86 {
                             }
 
                             continue 'outer;
+                        } else {
+                            // The relocation's data size overruns the symbol's remaining code
+                            // (e.g. a 4-byte relocation inside a 2-byte symbol, as produced by
+                            // delinked/overlapping label symbols). It can't be inline data, so
+                            // stop scanning relocations at this address and fall through to
+                            // decode the bytes as a normal instruction. Without this `break` the
+                            // inner loop re-peeks the same relocation forever, since nothing
+                            // advances `reloc_iter` or the decoder when `set_position` fails.
+                            break;
                         }
                     }
                     Ordering::Greater => break,
@@ -408,6 +417,11 @@ impl Arch for ArchX86 {
                             new_address = address + reloc_size as u64;
                             decoder.set_ip(new_address);
                             continue 'outer;
+                        } else {
+                            // Relocation can't fit the symbol's remaining bytes (see the note in
+                            // scan_instructions_internal); decode them as a normal instruction
+                            // rather than spinning on the same relocation.
+                            break;
                         }
                     }
                     Ordering::Greater => break,
@@ -597,6 +611,32 @@ mod test {
         assert_eq!(scanned[1].size, 7);
         assert_eq!(scanned[1].opcode, iced_x86::Mnemonic::Mov as u16);
         assert_eq!(scanned[1].branch_dest, None);
+    }
+
+    #[test]
+    fn test_scan_instructions_reloc_overruns_code() {
+        // Regression: a relocation that starts at the symbol but whose data size (4 bytes for
+        // a DIR32) overruns the symbol's code window. This is produced by delinked/overlapping
+        // label symbols (e.g. a 2-byte `LAB_x+1` sitting on a relocation). Previously the
+        // inner relocation loop re-peeked the same relocation forever because `set_position`
+        // failed and nothing advanced; the scan must instead decode the bytes as a normal
+        // instruction and terminate.
+        let arch = ArchX86 { arch: Architecture::X86, endianness: object::Endianness::Little };
+        let code = [0x00, 0x00]; // `add [eax], al` — 2 bytes, shorter than the 4-byte reloc
+        let relocations = [Relocation {
+            flags: RelocationFlags::Coff(pe::IMAGE_REL_I386_DIR32),
+            address: 0,
+            target_symbol: 0,
+            addend: 0,
+        }];
+        let scanned = arch
+            .scan_instructions_internal(0, &code, 0, &relocations, &DiffObjConfig::default())
+            .unwrap();
+        assert_eq!(scanned.len(), 1);
+        assert_eq!(scanned[0].address, 0);
+        assert_eq!(scanned[0].size, 2);
+        assert_eq!(scanned[0].opcode, iced_x86::Mnemonic::Add as u16);
+        assert_eq!(scanned[0].branch_dest, None);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`ArchX86::scan_instructions_internal` (and `infer_function_size`) walk a symbol''s code with a peekable relocation iterator. When a relocation starts exactly at the current address, the code treats it as inline data — advancing the decoder by the relocation''s size, recording a `OPCODE_DATA` `InstructionRef`, consuming the relocation, and `continue`-ing the outer loop. All of that lives **inside** `if decoder.set_position(pos + size).is_ok() { ... }`.

`set_position` fails when `pos + size` exceeds the code length — i.e. the relocation''s data width overruns the symbol''s remaining bytes. There is no `else`, so on failure nothing advances the relocation iterator or the decoder, and the inner `while let Some(reloc) = reloc_iter.peek()` re-peeks the **same** relocation at the **same** address forever. A hard hang (100% CPU, never returns).

This is reachable from real input: delinked or overlapping label symbols can produce a tiny symbol whose code window is smaller than a relocation that starts inside it — e.g. a 2-byte `LAB_xxxx+1` sitting on a 4-byte `REL32`. (Found while diffing delinked x64 Windows objects.)

## Fix

Add `else { break; }` at both sites. When the relocation can't fit the symbol's remaining bytes, stop scanning relocations for this address and fall through to decode the bytes as a normal instruction — the same exit the `Ordering::Greater` arm already uses.

Why this is correct:

- `break` exits only the **inner** relocation loop, not the `''outer` decode loop. Control falls to `decoder.decode_out(...)`, which decodes a real instruction. So relocation handling is **not** disabled for the rest of the symbol — it resumes at the next instruction address.
- The un-fittable relocation isn''t lost: after one normal instruction is decoded, the IP moves past `reloc.address`, so on the next pass it matches `Ordering::Less` and is consumed/skipped — correct, since those bytes have now been decoded as an instruction and can''t also be inline data.
- `set_position` having failed means the position never moved; the iced decoder is bounded by the `code` slice, so decoding stays in-bounds, and `decode_out` always advances the IP by ≥1, guaranteeing termination.

## Test

Adds `test_scan_instructions_reloc_overruns_code`: a 2-byte symbol (`00 00`) with a `DIR32` relocation at offset 0. Without the fix the scan loops forever; with it, the scan terminates and yields a single 2-byte `add` instruction. Verified the test hangs (killed at 30s) on the pre-fix code and passes after; full `objdiff-core --features x86` lib suite stays green (23/23).