### PR TITLE
Increase readability of symbol sizes

### DIFF
--- a/objdiff-gui/src/views/symbol_diff.rs
+++ b/objdiff-gui/src/views/symbol_diff.rs
@@ -606,14 +606,14 @@ fn symbol_ui(
     if diff_config.show_symbol_sizes == ShowSymbolSizes::Decimal {
         write_text(
             &format!(" (size={})", symbol.size),
-            appearance.deemphasized_text_color,
+            appearance.text_color,
             &mut job,
             appearance.code_font.clone(),
         );
     } else if diff_config.show_symbol_sizes == ShowSymbolSizes::Hex {
         write_text(
             &format!(" (size={:x})", symbol.size),
-            appearance.deemphasized_text_color,
+            appearance.text_color,
             &mut job,
             appearance.code_font.clone(),
         );


### PR DESCRIPTION
Before
<img width="490" height="122" alt="image" src="https://github.com/user-attachments/assets/e0a2c0ab-72e0-478c-af88-a57abd3e2c5a" />
After
<img width="492" height="124" alt="image" src="https://github.com/user-attachments/assets/f1b526ad-84f1-40f3-ab11-faa88db90863" />
