### PR TITLE
Fix diffing of relocations to symbols that have compiler-generated names

### DIFF
--- a/objdiff-core/src/diff/code.rs
+++ b/objdiff-core/src/diff/code.rs
@@ -12,9 +12,12 @@ use super::{
     InstructionBranchTo, InstructionDiffKind, InstructionDiffRow, PreferredStringEncoding,
     SymbolDiff, display::display_ins_data_literals,
 };
-use crate::obj::{
-    InstructionArg, InstructionArgValue, InstructionRef, Object, ResolvedInstructionRef,
-    ResolvedRelocation, ResolvedSymbol, SymbolKind,
+use crate::{
+    diff::{address_eq, section_name_eq},
+    obj::{
+        InstructionArg, InstructionArgValue, InstructionRef, Object, ResolvedInstructionRef,
+        ResolvedRelocation, ResolvedSymbol, SymbolKind,
+    },
 };
 
 pub fn no_diff_code(
@@ -266,36 +269,6 @@ fn resolve_branches(ops: &[InstructionRef], rows: &mut [InstructionDiffRow]) {
     }
 }
 
-pub(crate) fn address_eq(left: ResolvedRelocation, right: ResolvedRelocation) -> bool {
-    if right.symbol.size == 0 && left.symbol.size != 0 {
-        // The base relocation is against a pool but the target relocation isn't.
-        // This can happen in rare cases where the compiler will generate a pool+addend relocation
-        // in the base's data, but the one detected in the target is direct with no addend.
-        // Just check that the final address is the same so these count as a match.
-        left.symbol.address as i64 + left.relocation.addend
-            == right.symbol.address as i64 + right.relocation.addend
-    } else {
-        // But otherwise, if the compiler isn't using a pool, we're more strict and check that the
-        // target symbol address and relocation addend both match exactly.
-        left.symbol.address == right.symbol.address
-            && left.relocation.addend == right.relocation.addend
-    }
-}
-
-pub(crate) fn section_name_eq(
-    left_obj: &Object,
-    right_obj: &Object,
-    left_section_index: usize,
-    right_section_index: usize,
-) -> bool {
-    left_obj.sections.get(left_section_index).is_some_and(|left_section| {
-        right_obj
-            .sections
-            .get(right_section_index)
-            .is_some_and(|right_section| left_section.name == right_section.name)
-    })
-}
-
 fn ins_data_literals_eq(
     left_obj: &Object,
     right_obj: &Object,
@@ -340,10 +313,10 @@ fn reloc_eq(
 
     let symbol_name_addend_matches = left_reloc.symbol.name == right_reloc.symbol.name
         && left_reloc.relocation.addend == right_reloc.relocation.addend;
-    match (&left_reloc.symbol.section, &right_reloc.symbol.section) {
+    match (left_reloc.symbol.section, right_reloc.symbol.section) {
         (Some(sl), Some(sr)) => {
             // Match if section and name or address match
-            section_name_eq(left_obj, right_obj, *sl, *sr)
+            section_name_eq(left_obj, right_obj, sl, sr)
                 && (diff_config.function_reloc_diffs == FunctionRelocDiffs::DataValue
                     || symbol_name_addend_matches
                     || address_eq(left_reloc, right_reloc))

--- a/objdiff-core/src/diff/code.rs
+++ b/objdiff-core/src/diff/code.rs
@@ -16,7 +16,7 @@ use crate::{
     diff::{address_eq, section_name_eq, symbol_name_matches},
     obj::{
         InstructionArg, InstructionArgValue, InstructionRef, Object, ResolvedInstructionRef,
-        ResolvedRelocation, ResolvedSymbol, SymbolKind,
+        ResolvedRelocation, ResolvedSymbol, SymbolFlag, SymbolKind,
     },
 };
 
@@ -321,6 +321,11 @@ fn reloc_eq(
             let mut name_ok = false;
             if diff_config.function_reloc_diffs == FunctionRelocDiffs::DataValue {
                 // Ignore names entirely
+                name_ok = true;
+            } else if left_reloc.symbol.flags.contains(SymbolFlag::CompilerGenerated)
+                && right_reloc.symbol.flags.contains(SymbolFlag::CompilerGenerated)
+            {
+                // Match if both symbol names are fully compiler-generated
                 name_ok = true;
             } else if symbol_name_addend_matches || address_eq(left_reloc, right_reloc) {
                 // Match if name+addend or address match

--- a/objdiff-core/src/diff/code.rs
+++ b/objdiff-core/src/diff/code.rs
@@ -13,7 +13,7 @@ use super::{
     SymbolDiff, display::display_ins_data_literals,
 };
 use crate::{
-    diff::{address_eq, section_name_eq},
+    diff::{address_eq, section_name_eq, symbol_name_matches},
     obj::{
         InstructionArg, InstructionArgValue, InstructionRef, Object, ResolvedInstructionRef,
         ResolvedRelocation, ResolvedSymbol, SymbolKind,
@@ -311,7 +311,7 @@ fn reloc_eq(
         return true;
     }
 
-    let symbol_name_addend_matches = left_reloc.symbol.name == right_reloc.symbol.name
+    let symbol_name_addend_matches = symbol_name_matches(left_reloc.symbol, right_reloc.symbol)
         && left_reloc.relocation.addend == right_reloc.relocation.addend;
     match (left_reloc.symbol.section, right_reloc.symbol.section) {
         (Some(sl), Some(sr)) => {

--- a/objdiff-core/src/diff/code.rs
+++ b/objdiff-core/src/diff/code.rs
@@ -315,15 +315,31 @@ fn reloc_eq(
         && left_reloc.relocation.addend == right_reloc.relocation.addend;
     match (left_reloc.symbol.section, right_reloc.symbol.section) {
         (Some(sl), Some(sr)) => {
-            // Match if section and name or address match
-            section_name_eq(left_obj, right_obj, sl, sr)
-                && (diff_config.function_reloc_diffs == FunctionRelocDiffs::DataValue
-                    || symbol_name_addend_matches
-                    || address_eq(left_reloc, right_reloc))
-                && (diff_config.function_reloc_diffs == FunctionRelocDiffs::NameAddress
-                    || left_reloc.symbol.kind != SymbolKind::Object
-                    || right_reloc.symbol.size == 0 // Likely a pool symbol like ...data, don't treat this as a diff
-                    || ins_data_literals_eq(left_obj, right_obj, left_ins, right_ins, diff_config))
+            if !section_name_eq(left_obj, right_obj, sl, sr) {
+                return false;
+            };
+            let mut name_ok = false;
+            if diff_config.function_reloc_diffs == FunctionRelocDiffs::DataValue {
+                // Ignore names entirely
+                name_ok = true;
+            } else if symbol_name_addend_matches || address_eq(left_reloc, right_reloc) {
+                // Match if name+addend or address match
+                name_ok = true;
+            }
+            let mut value_ok = false;
+            if diff_config.function_reloc_diffs == FunctionRelocDiffs::NameAddress {
+                // Ignore data values entirely
+                value_ok = true;
+            } else if left_reloc.symbol.kind != SymbolKind::Object {
+                // Not a data symbol, don't diff value
+                value_ok = true;
+            } else if right_reloc.symbol.size == 0 {
+                // Likely a pool symbol like ...data, don't treat this as a diff
+                value_ok = true;
+            } else if ins_data_literals_eq(left_obj, right_obj, left_ins, right_ins, diff_config) {
+                value_ok = true;
+            }
+            name_ok && value_ok
         }
         (Some(_), None) | (None, Some(_)) | (None, None) => symbol_name_addend_matches,
     }

--- a/objdiff-core/src/diff/data.rs
+++ b/objdiff-core/src/diff/data.rs
@@ -54,8 +54,17 @@ fn reloc_eq(
             if !section_name_eq(left_obj, right_obj, sl, sr) {
                 return false;
             };
-            // Match if name+addend or address match
-            symbol_name_addend_matches || address_eq(left_reloc, right_reloc)
+            let mut name_ok = false;
+            if left_reloc.symbol.flags.contains(SymbolFlag::CompilerGenerated)
+                && right_reloc.symbol.flags.contains(SymbolFlag::CompilerGenerated)
+            {
+                // Match if both symbol names are fully compiler-generated
+                name_ok = true;
+            } else if symbol_name_addend_matches || address_eq(left_reloc, right_reloc) {
+                // Match if name+addend or address match
+                name_ok = true;
+            }
+            name_ok
         }
         (Some(_), None) | (None, Some(_)) | (None, None) => symbol_name_addend_matches,
     }

--- a/objdiff-core/src/diff/data.rs
+++ b/objdiff-core/src/diff/data.rs
@@ -6,9 +6,11 @@ use similar::{Algorithm, capture_diff_slices, diff_ratio};
 
 use super::{
     DataDiff, DataDiffKind, DataDiffRow, DataRelocationDiff, ObjectDiff, SectionDiff, SymbolDiff,
-    code::{address_eq, section_name_eq},
 };
-use crate::obj::{Object, Relocation, ResolvedRelocation, Symbol, SymbolFlag, SymbolKind};
+use crate::{
+    diff::{address_eq, section_name_eq, symbol_name_matches},
+    obj::{Object, Relocation, ResolvedRelocation, Symbol, SymbolFlag, SymbolKind},
+};
 
 pub fn diff_bss_symbol(
     left_obj: &Object,
@@ -35,33 +37,23 @@ pub fn diff_bss_symbol(
     ))
 }
 
-pub fn symbol_name_matches(left: &Symbol, right: &Symbol) -> bool {
-    if let Some(left_name) = &left.normalized_name
-        && let Some(right_name) = &right.normalized_name
-    {
-        left_name == right_name
-    } else {
-        left.name == right.name
-    }
-}
-
 fn reloc_eq(
     left_obj: &Object,
     right_obj: &Object,
-    left: ResolvedRelocation,
-    right: ResolvedRelocation,
+    left_reloc: ResolvedRelocation,
+    right_reloc: ResolvedRelocation,
 ) -> bool {
-    if left.relocation.flags != right.relocation.flags {
+    if left_reloc.relocation.flags != right_reloc.relocation.flags {
         return false;
     }
 
-    let symbol_name_addend_matches = symbol_name_matches(left.symbol, right.symbol)
-        && left.relocation.addend == right.relocation.addend;
-    match (left.symbol.section, right.symbol.section) {
+    let symbol_name_addend_matches = symbol_name_matches(left_reloc.symbol, right_reloc.symbol)
+        && left_reloc.relocation.addend == right_reloc.relocation.addend;
+    match (left_reloc.symbol.section, right_reloc.symbol.section) {
         (Some(sl), Some(sr)) => {
             // Match if section and name+addend or address match
             section_name_eq(left_obj, right_obj, sl, sr)
-                && (symbol_name_addend_matches || address_eq(left, right))
+                && (symbol_name_addend_matches || address_eq(left_reloc, right_reloc))
         }
         (Some(_), None) | (None, Some(_)) | (None, None) => symbol_name_addend_matches,
     }

--- a/objdiff-core/src/diff/data.rs
+++ b/objdiff-core/src/diff/data.rs
@@ -51,9 +51,11 @@ fn reloc_eq(
         && left_reloc.relocation.addend == right_reloc.relocation.addend;
     match (left_reloc.symbol.section, right_reloc.symbol.section) {
         (Some(sl), Some(sr)) => {
-            // Match if section and name+addend or address match
-            section_name_eq(left_obj, right_obj, sl, sr)
-                && (symbol_name_addend_matches || address_eq(left_reloc, right_reloc))
+            if !section_name_eq(left_obj, right_obj, sl, sr) {
+                return false;
+            };
+            // Match if name+addend or address match
+            symbol_name_addend_matches || address_eq(left_reloc, right_reloc)
         }
         (Some(_), None) | (None, Some(_)) | (None, None) => symbol_name_addend_matches,
     }

--- a/objdiff-core/src/diff/mod.rs
+++ b/objdiff-core/src/diff/mod.rs
@@ -14,10 +14,12 @@ use crate::{
         data::{
             diff_bss_section, diff_bss_symbol, diff_data_section, diff_data_symbol,
             diff_generic_section, no_diff_bss_section, no_diff_data_section, no_diff_data_symbol,
-            symbol_name_matches,
         },
     },
-    obj::{InstructionRef, Object, Relocation, SectionKind, Symbol, SymbolFlag, SymbolKind},
+    obj::{
+        InstructionRef, Object, Relocation, ResolvedRelocation, SectionKind, Symbol, SymbolFlag,
+        SymbolKind,
+    },
 };
 
 pub mod code;
@@ -954,4 +956,44 @@ pub enum DiffSide {
     Target,
     /// The base side of the diff.
     Base,
+}
+
+pub(crate) fn address_eq(left: ResolvedRelocation, right: ResolvedRelocation) -> bool {
+    if right.symbol.size == 0 && left.symbol.size != 0 {
+        // The base relocation is against a pool but the target relocation isn't.
+        // This can happen in rare cases where the compiler will generate a pool+addend relocation
+        // in the base's data, but the one detected in the target is direct with no addend.
+        // Just check that the final address is the same so these count as a match.
+        left.symbol.address as i64 + left.relocation.addend
+            == right.symbol.address as i64 + right.relocation.addend
+    } else {
+        // But otherwise, if the compiler isn't using a pool, we're more strict and check that the
+        // target symbol address and relocation addend both match exactly.
+        left.symbol.address == right.symbol.address
+            && left.relocation.addend == right.relocation.addend
+    }
+}
+
+pub(crate) fn section_name_eq(
+    left_obj: &Object,
+    right_obj: &Object,
+    left_section_index: usize,
+    right_section_index: usize,
+) -> bool {
+    left_obj.sections.get(left_section_index).is_some_and(|left_section| {
+        right_obj
+            .sections
+            .get(right_section_index)
+            .is_some_and(|right_section| left_section.name == right_section.name)
+    })
+}
+
+pub(crate) fn symbol_name_matches(left: &Symbol, right: &Symbol) -> bool {
+    if let Some(left_name) = &left.normalized_name
+        && let Some(right_name) = &right.normalized_name
+    {
+        left_name == right_name
+    } else {
+        left.name == right.name
+    }
 }


### PR DESCRIPTION
Fixes two bugs when diffing relocations, which were treated inconsistently by different parts of objdiff:

* When diffing functions, partially compiler-generated names (e.g. `symbol$1234` and `symbol$2345`) are now normalized for relocation diffing. (This was already done when diffing data and when pairing up symbols.)
* When diffing both functions and data, fully compiler-generated names (e.g. `@1234` and `@2345`) are now ignored for relocation diffing. (This was already done when pairing up symbols.)

In practice this means that "Name or address" mode can now be used more reliably even in TUs with stripped data that causes the addresses to not match up (which is common in projects that use precompiled headers like TWW/TP). Prior to these fixes real name diffs were hard to spot because they could get mixed up in dozens of fake `@1234` vs `@2345` diffs. And if you use "Data value" mode they don't show up at all.

Before:
<img width="1146" height="649" alt="image" src="https://github.com/user-attachments/assets/260884e1-974f-46b1-bd7a-7cef306e8399" />
After:
<img width="1147" height="640" alt="image" src="https://github.com/user-attachments/assets/66512b83-e457-4325-933a-cf6ab52732cc" />

It also fixes RTTI data sometimes showing as nonmatching because it contains relocations to compiler-generated symbols.

Before:
<img width="1146" height="649" alt="image" src="https://github.com/user-attachments/assets/786a6fd6-0d4e-4e83-864e-175f28b5c17f" />
After:
<img width="1147" height="640" alt="image" src="https://github.com/user-attachments/assets/d45ec9dc-b8f9-4ebf-a0c4-24e17d6da5e9" />
