### PR TITLE
MSVC: Ignore unwinds and catches when inferring function sizes

### DIFF
--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -335,6 +335,8 @@ fn infer_symbol_sizes(arch: &dyn Arch, symbols: &mut [Symbol], sections: &[Secti
                 SymbolKind::Function | SymbolKind::Object => {
                     // For function/object symbols, find the next function/object
                     matches!(next_symbol.kind, SymbolKind::Function | SymbolKind::Object)
+                        && !next_symbol.name.starts_with("__unwind$")
+                        && !next_symbol.name.starts_with("__catch$")
                 }
                 SymbolKind::Unknown | SymbolKind::Section => {
                     // For labels (or anything else), stop at any symbol

--- a/objdiff-core/src/obj/read.rs
+++ b/objdiff-core/src/obj/read.rs
@@ -332,11 +332,17 @@ fn infer_symbol_sizes(arch: &dyn Arch, symbols: &mut [Symbol], sections: &[Secti
                 break None;
             }
             if match symbol.kind {
+                SymbolKind::Function
+                    if next_symbol.kind == SymbolKind::Function
+                        && (next_symbol.name.starts_with("__unwind$")
+                            || next_symbol.name.starts_with("__catch$")) =>
+                {
+                    // MSVC unwinds/catches count as functions, but shouldn't cut off the function they're from.
+                    false
+                }
                 SymbolKind::Function | SymbolKind::Object => {
                     // For function/object symbols, find the next function/object
                     matches!(next_symbol.kind, SymbolKind::Function | SymbolKind::Object)
-                        && !next_symbol.name.starts_with("__unwind$")
-                        && !next_symbol.name.starts_with("__catch$")
                 }
                 SymbolKind::Unknown | SymbolKind::Section => {
                     // For labels (or anything else), stop at any symbol


### PR DESCRIPTION
This makes functions with names like `__unwind$1234` or `__catch$1234` be ignored so that their contents will show up in the function preceding them instead of in their own separate function. Currently the function preceding them gets cut off.

Fixes #389