### PR TITLE
`diff_order_for_section_name` warning instead of crash

### DIFF
--- a/objdiff-core/src/diff/mod.rs
+++ b/objdiff-core/src/diff/mod.rs
@@ -6,7 +6,7 @@ use alloc::{
 };
 use core::{cmp::Ordering, num::NonZeroU32, ops::Range};
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 
 use crate::{
     diff::{
@@ -487,15 +487,18 @@ fn diff_order_for_section_name(
         .collect();
 
     let mut expected_right_order_idx = 0;
-    for (left_order_idx, (left_symbol_idx, _left_symbol)) in left_paired_symbols.iter().enumerate()
-    {
+    for (left_order_idx, (left_symbol_idx, left_symbol)) in left_paired_symbols.iter().enumerate() {
         let right_symbol_idx = left_sym_idx_to_right_sym_idx.get(left_symbol_idx).unwrap();
-        let right_order_idx = right_paired_symbols
-            .iter()
-            .position(|(sym_idx, _)| sym_idx == right_symbol_idx)
-            .ok_or_else(|| {
-                anyhow!("Failed to find right side symbol for paired left side symbol")
-            })?;
+        let Some(right_order_idx) =
+            right_paired_symbols.iter().position(|(sym_idx, _)| sym_idx == right_symbol_idx)
+        else {
+            log::warn!(
+                "Failed to find right side symbol for paired left side symbol {} in section {}",
+                left_symbol.name,
+                section_name
+            );
+            continue;
+        };
         if right_order_idx == left_order_idx {
             // In the correct spot.
             left_diff.symbols[*left_symbol_idx].order = Some(Ordering::Equal);


### PR DESCRIPTION
Commit f2f813e66bdf13ce0592eebce339c8c09920c553 added in a function [diff_order_for_section_name](https://github.com/encounter/objdiff/blame/fba10a617154f19b3fc25c8817dc81f81d8489b5/objdiff-core/src/diff/mod.rs#L459) which crashes out with the error message `Failed to find right side symbol for paired left side symbol`

This change makes this function log a warning instead of crashing out and also provides context for the expected symbol name and section that is expected.

v3.8.1:
<img width="885" height="97" alt="image" src="https://github.com/user-attachments/assets/0794f29b-61d4-467a-bce3-4b8e2f976466" />

v3.7.1:
<img width="885" height="97" alt="image" src="https://github.com/user-attachments/assets/da73a9bc-fa18-4fd8-b7c7-6dfeda4d6cd3" />

Patched:
<img width="885" height="97" alt="image" src="https://github.com/user-attachments/assets/b659a1b9-15de-402f-8427-6fc331682624" />